### PR TITLE
Repetitions and Template use revision

### DIFF
--- a/WebContent/WEB-INF/jsp/admin-tools/admin-main-menu.jsp
+++ b/WebContent/WEB-INF/jsp/admin-tools/admin-main-menu.jsp
@@ -29,7 +29,7 @@
 						Treatment Plan Template</button>
 				</div>
 				<input type="hidden" name="requestedAction"	value="plan-create-start">
-				<input type="hidden" name="path" value="creatingPlanTemplate">
+				<input type="hidden" name="path" value="treatmentPlanTemplate">
 			</form>
 			</p>
 
@@ -40,7 +40,7 @@
 						Treatment Plan Template</button>
 				</div>
 				<input type="hidden" name="requestedAction" value="plan-edit-start">
-				<input type="hidden" name="path" value="editingPlanTemplate">
+				<input type="hidden" name="path" value="treatmentPlanTemplate">
 			</form>
 			</p>
 		</div>
@@ -54,7 +54,7 @@
 						Template</button>
 				</div>
 				<input type="hidden" name="requestedAction" value="stage-create-start">
-				<input type="hidden" name="path" value="creatingStageTemplate">
+				<input type="hidden" name="path" value="stageTemplate">
 			</form>
 			</p>
 			<p>
@@ -65,7 +65,7 @@
 						Stage Template</button>
 				</div>
 				<input type="hidden" name="requestedAction" value="stage-edit-start">
-				<input type="hidden" name="path" value="editingStageTemplate">
+				<input type="hidden" name="path" value="stageTemplate">
 			</form>
 			</p>
 		</div>
@@ -78,7 +78,7 @@
 						Task Template</button>
 				</div>
 				<input type="hidden" name="requestedAction" value="create-task-start">
-				<input type="hidden" name="path" value="creatingTaskTemplate">
+				<input type="hidden" name="path" value="taskTemplate">
 			</form>
 			</p>
 			<p>
@@ -88,7 +88,7 @@
 						Task Template</button>
 				</div>
 				<input type="hidden" name="requestedAction" value="edit-task-start">
-				<input type="hidden" name="path" value="editingTaskTemplate">
+				<input type="hidden" name="path" value="taskTemplate">
 			</form>
 			</p>
 		</div>

--- a/WebContent/WEB-INF/jsp/client-tools/client-main-menu.jsp
+++ b/WebContent/WEB-INF/jsp/client-tools/client-main-menu.jsp
@@ -20,14 +20,14 @@
 
   <p>
     <form class="form-inline" action="" method="POST">
-      <div><button type="submit" class="btn btn-primary" disabled>Another Option</button></div>
+      <div><button type="submit" class="btn btn-primary" disabled>Manage My Treatment Plans</button></div>
       <input type="hidden" name="requestedAction" value="editplan">
     </form>
   </p>
 
   <p>
     <form class="form-inline" action="" method="POST">
-      <div><button type="submit" class="btn btn-primary" disabled>Option 3</button></div>
+      <div><button type="submit" class="btn btn-primary" disabled>Another Option</button></div>
       <input type="hidden" name="requestedAction" value="assign-treatment-plan-start">
       <input type="hidden" name="path" value="assignClientTreatmentPlan">
     </form>

--- a/WebContent/WEB-INF/jsp/client-tools/select-plan.jsp
+++ b/WebContent/WEB-INF/jsp/client-tools/select-plan.jsp
@@ -21,7 +21,7 @@
 	<form class="form-horizontal" action="/secure/ClientSelectPlan" method="POST">
 		<input type="hidden" name="requestedAction" value="select-plan-load">
 		<input type="hidden" name="path" value="client-execute-plan">
-
+		<input type="hidden" name="initialize" value="no">
 		
         <div class="form-group">
             <label for="selectedPlanID" class="col-sm-3 control-label">Plans in Progress:</label>
@@ -48,6 +48,7 @@
 	<form class="form-horizontal" action="/secure/ClientSelectPlan" method="POST">
 		<input type="hidden" name="requestedAction" value="select-plan-load">
 		<input type="hidden" name="path" value="client-execute-plan">
+		<input type="hidden" name="initialize" value="yes">
 
 		
         <div class="form-group">
@@ -75,6 +76,7 @@
 	<form class="form-horizontal" action="/secure/ClientSelectPlan" method="POST">
 		<input type="hidden" name="requestedAction" value="select-plan-load">
 		<input type="hidden" name="path" value="client-execute-plan">
+		<input type="hidden" name="initialize" value="no">
 
 		
         <div class="form-group">

--- a/WebContent/WEB-INF/jsp/message-modal.jsp
+++ b/WebContent/WEB-INF/jsp/message-modal.jsp
@@ -11,6 +11,15 @@
     </c:if>
     <!-- END ERROR MESSAGE DISPLAY -->
     
+    <!-- WARNING MESSAGE DISPLAY  -->
+    <c:if test="${warningMessage != null}">
+		<div class="alert alert-warning alert-dismissible" role="alert">
+		  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+		  <strong>Warning!</strong> ${warningMessage}
+		</div>
+    </c:if>
+    <!-- END WARNING MESSAGE DISPLAY -->
+    
     <!-- SUCCESS MESSAGE DISPLAY  -->
     <c:if test="${successMessage != null}">
 		<div class="alert alert-success alert-dismissible" role="alert">
@@ -20,11 +29,12 @@
     </c:if>
     <!-- END SUCCESS MESSAGE DISPLAY -->
     
-    <!-- SUCCESS MESSAGE DISPLAY  -->
+    <!-- INFO MESSAGE DISPLAY  -->
     <c:if test="${infoMessage != null}">
 		<div class="alert alert-info alert-dismissible" role="alert">
 		  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 		  <strong>Heads up!</strong> ${infoMessage}
 		</div>
     </c:if>
-    <!-- END SUCCESS MESSAGE DISPLAY -->
+    <!-- END INFO MESSAGE DISPLAY -->
+    

--- a/WebContent/WEB-INF/jsp/therapist-tools/therapist-main-menu.jsp
+++ b/WebContent/WEB-INF/jsp/therapist-tools/therapist-main-menu.jsp
@@ -20,6 +20,7 @@
     <form class="form-inline" action="/secure/LoadData" method="POST">
       <div><button type="submit" class="btn btn-primary" disabled>Create Treatment Plan</button></div>
       <input type="hidden" name="requestedAction" value="createplan">
+      <input type="hidden" name="path" value="assignClientTreatmentPlan">
     </form>
   </p>
 
@@ -27,6 +28,7 @@
     <form class="form-inline" action="/secure/LoadData" method="POST">
       <div><button type="submit" class="btn btn-primary" disabled>Edit Treatment Plans</button></div>
       <input type="hidden" name="requestedAction" value="editplan">
+      <input type="hidden" name="path" value="assignClientTreatmentPlan">
     </form>
   </p>
 
@@ -40,8 +42,9 @@
 
   <p>
     <form class="form-inline" action="/secure/LoadData" method="POST">
-      <div><button type="submit" class="btn btn-primary" disabled>View Client Progress</button></div>
-      <input type="hidden" name="requestedAction" value="viewclient">
+      <div><button type="submit" class="btn btn-primary" disabled>Manage Clients</button></div>
+      <input type="hidden" name="requestedAction" value="manage-clients">
+      <input type="hidden" name="path" value="assignClientTreatmentPlan">
     </form>
   </p>
 

--- a/WebContent/WEB-INF/jsp/treatment-plans/stage-create.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/stage-create.jsp
@@ -8,13 +8,13 @@
 
     <div class="page-header">
     
-        <c:if test="${path == 'creatingStageTemplate' }"><h1>Create a Stage Template</h1></c:if>
-        <c:if test="${path != 'creatingStageTemplate' }"><h2>Add a Stage to: ${treatmentPlan.title} (${treatmentPlan.treatmentPlanID })</h2></c:if>
+        <c:if test="${path == 'stageTemplate' }"><h1>Create a Stage Template</h1></c:if>
+        <c:if test="${path != 'stageTemplate' }"><h2>Add a Stage to: ${treatmentPlan.title} (${treatmentPlan.treatmentPlanID })</h2></c:if>
     </div>
     
 	<c:import url="/WEB-INF/jsp/message-modal.jsp"/>
 
-	<c:if test="${path != 'creatingStageTemplate' }">
+	<c:if test="${path != 'stageTemplate' }">
 		<div class="well well-sm">
 			<form class="form-horizontal" action="/secure/CreateStage" method="POST">
 				<input type="hidden" name="requestedAction" value="stage-add-default">

--- a/WebContent/WEB-INF/jsp/treatment-plans/stage-create.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/stage-create.jsp
@@ -17,7 +17,7 @@
 	<c:if test="${path != 'stageTemplate' }">
 		<div class="well well-sm">
 			<form class="form-horizontal" action="/secure/CreateStage" method="POST">
-				<input type="hidden" name="requestedAction" value="stage-add-default">
+				<input type="hidden" name="requestedAction" value="stage-add-default-template">
 				<input type="hidden" name="path" value="${path }">
 				<input type="hidden" name="treatmentPlanID" value="${treatmentPlan.treatmentPlanID }">
 				

--- a/WebContent/WEB-INF/jsp/treatment-plans/stage-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/stage-edit.jsp
@@ -91,7 +91,7 @@
 				  	<input type="hidden" name="taskID" value="${task.taskID}"/>
 				  	<input type="hidden" name="taskTitle" value="${task.title}"/>
 					<a role="button" data-toggle="collapse" href="#collapse${task.taskID }" aria-expanded="true" aria-controls="collapse${task.taskID }">
-			          ${task.taskOrderForUserDisplay } - <span class="">${task.title }</span>
+			          ${task.taskOrderForUserDisplay } - <span class="">${task.title } (${task.repetitions})</span>
 			        </a>
 			        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
 			        <a role="button" href="/secure/EditStage?requestedAction=delete-task&path=${path}&stageID=${stage.stageID}&taskID=${task.taskID}" class="btn btn-default btn-xs pull-right" title="Delete task:${task.title }">

--- a/WebContent/WEB-INF/jsp/treatment-plans/stage-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/stage-edit.jsp
@@ -125,6 +125,7 @@
 		    <input type="hidden" name="requestedAction" value="stage-edit-add-goal">
 		    <input type="hidden" name="path" value="${path }" >
 		    <input type="hidden" name="stageID" value="${stage.stageID}" >
+		    <input type="hidden" name="treatmentPlanID" value="${treatmentPlanID }">
 		      <div class="modal-header">
 		        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 		        <h4 class="modal-title" id="newStageGoalModalLabel">Enter a new stage goal.</h4>

--- a/WebContent/WEB-INF/jsp/treatment-plans/stage-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/stage-edit.jsp
@@ -36,7 +36,8 @@
 	<form class="form-horizontal" action="/secure/EditStage" method="POST">
 		<input type="hidden" name="requestedAction" value="stage-edit-name">
 		<input type="hidden" name="path" value="${path }">	
-		<input type="hidden" name="stageID" value="${stage.stageID }" >	
+		<input type="hidden" name="stageID" value="${stage.stageID }" >
+		<input type="hidden" name="treatmentPlanID" value="${treatmentPlanID }">	
 		
         <div class="form-group">
             <label for="stageTitle" class="col-sm-2 control-label">Stage Name</label>
@@ -78,7 +79,7 @@
 		
 		<label for="stageList" class="control-label">Tasks
 
-       			<a role="button" href="/secure/CreateTask?requestedAction=create-task-start&path=${path}&stageID=${stage.stageID}" class="btn btn-default btn-xs" title="Add a task to this stage." <c:if test="${stage.stageID == null }">disabled</c:if>>
+       			<a role="button" href="/secure/CreateTask?requestedAction=create-task-start&path=${path}&treatmentPlanID=${treatmentPlanID}&stageID=${stage.stageID}" class="btn btn-default btn-xs" title="Add a task to this stage." <c:if test="${stage.stageID == null }">disabled</c:if>>
 				  <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
 				</a>
 
@@ -92,11 +93,11 @@
 			          ${task.taskOrderForUserDisplay } - <span class="">${task.title } (${task.repetitions})</span>
 			        </a>
 			        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-			        <a role="button" href="/secure/EditStage?requestedAction=delete-task&path=${path}&stageID=${stage.stageID}&taskID=${task.taskID}" class="btn btn-default btn-xs pull-right" title="Delete task:${task.title }">
+			        <a role="button" href="/secure/EditStage?requestedAction=delete-task&path=${path}&treatmentPlanID=${treatmentPlanID}&stageID=${stage.stageID}&taskID=${task.taskID}" class="btn btn-default btn-xs pull-right" title="Delete task:${task.title }">
 					  <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
 					</a>
 					
-			        <a role="button" href="/secure/EditTask?requestedAction=edit-task-select-task&path=${path}&stageID=${stage.stageID}&taskID=${task.taskID}" class="btn btn-default btn-xs pull-right" title="Edit task: ${task.title }">
+			        <a role="button" href="/secure/EditTask?requestedAction=edit-task-select-task&path=${path}&treatmentPlanID=${treatmentPlanID}&stageID=${stage.stageID}&taskID=${task.taskID}" class="btn btn-default btn-xs pull-right" title="Edit task: ${task.title }">
 					  <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
 					</a>
 					

--- a/WebContent/WEB-INF/jsp/treatment-plans/stage-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/stage-edit.jsp
@@ -16,8 +16,8 @@
 		<input type="hidden" name="requestedAction" value="stage-edit-select-stage">
 		<input type="hidden" name="path" value="${path }">
 		
-		<div class="well well-sm">
-			<c:if test="${path=='editingStageTemplate'}">
+		<c:if test="${path=='stageTemplate'}">
+			<div class="well well-sm">
 				<div class="form-group">
 					<label for="selectedDefaultStageID" class="col-sm-2 control-label">Select Default Stage</label>
 			        <div class="col-sm-5">
@@ -29,10 +29,8 @@
 			            </select>
 			        </div>
 				</div>
-				
-			</c:if>
-		</div>
-		
+			</div>
+		</c:if>
 	</form>
 	
 	<form class="form-horizontal" action="/secure/EditStage" method="POST">

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
@@ -7,13 +7,13 @@
 <c:import url="/WEB-INF/jsp/header.jsp" />
 
 <div class="page-header">
-	<c:if test="${path=='creatingTaskTemplate' }"><h1>Create A Task Template</h1></c:if>
-	<c:if test="${path!='creatingTaskTemplate' }"><h1>Create a Task for the Stage: ${stage.title}</h1></c:if>
+	<c:if test="${path=='taskTemplate' }"><h1>Create A Task Template</h1></c:if>
+	<c:if test="${path!='taskTemplate' }"><h1>Create a Task for the Stage: ${stage.title}</h1></c:if>
 </div>
   
 <c:import url="/WEB-INF/jsp/message-modal.jsp"/>
 	
-	<c:if test="${path!='creatingTaskTemplate' }">
+	<c:if test="${path!='taskTemplate' }">
 		<div class="well well-sm">
 			<form class="form-horizontal" action="/secure/CreateTask" method="POST">
 				<input type="hidden" name="requestedAction" value="task-add-default">
@@ -75,7 +75,7 @@
 	    </form>
 	        
 	    <form class="form-horizontal" action="/secure/CreateTask" method="POST">
-			<input type="hidden" name="requestedAction" value="new-task-save">
+			<input type="hidden" name="requestedAction" value="create-new-task">
 			<input type="hidden" name="path" value="${path }">
 			<input type="hidden" name="stageID" value="${stage.stageID }">
 			<input type="hidden" name="taskTypeID" value="${task.taskTypeID }">

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
@@ -153,15 +153,16 @@
 		        </div>
 			</c:if>
 			
-			<div class="form-group">
-				<div class="checkbox col-sm-offset-2">
-				  <label>
-				    <input type="checkbox" value="checked" name="copyAsTemplate" id="copyAsTemplate">
-				    Make a copy for use as a default Task?
-				  </label>
-				</div>
-	        </div>
-
+			<c:if test="${path='clientTask' }">
+				<div class="form-group">
+					<div class="checkbox col-sm-offset-2">
+					  <label>
+					    <input type="checkbox" value="checked" name="copyAsTemplate" id="copyAsTemplate">
+					    Make a copy for use as a default Task?
+					  </label>
+					</div>
+		        </div>
+			</c:if>
 	        <button type="submit" class="btn btn-default col-sm-offset-2">Submit</button>
 
 	    </form>

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
@@ -16,7 +16,7 @@
 	<c:if test="${path!='taskTemplate' }">
 		<div class="well well-sm">
 			<form class="form-horizontal" action="/secure/CreateTask" method="POST">
-				<input type="hidden" name="requestedAction" value="task-add-default">
+				<input type="hidden" name="requestedAction" value="task-add-default-template">
 				<input type="hidden" name="path" value="${path }">
 				<input type="hidden" name="stageID" value="${stage.stageID }">
 				<input type="hidden" name="isTemplate" value="${task.template }">

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
@@ -22,7 +22,7 @@
 				<input type="hidden" name="isTemplate" value="${task.template }">
 				
 				<div>
-					<h3>Add a Predefined Stage</h3>
+					<h3>Add a Predefined Task</h3>
 				</div>
 				
 		        <div class="form-group">
@@ -75,7 +75,7 @@
 	    </form>
 	        
 	    <form class="form-horizontal" action="/secure/CreateTask" method="POST">
-			<input type="hidden" name="requestedAction" value="task-save">
+			<input type="hidden" name="requestedAction" value="new-task-save">
 			<input type="hidden" name="path" value="${path }">
 			<input type="hidden" name="stageID" value="${stage.stageID }">
 			<input type="hidden" name="taskTypeID" value="${task.taskTypeID }">

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-create.jsp
@@ -20,6 +20,7 @@
 				<input type="hidden" name="path" value="${path }">
 				<input type="hidden" name="stageID" value="${stage.stageID }">
 				<input type="hidden" name="isTemplate" value="${task.template }">
+				<input type="hidden" name="treatmentPlanID" value="${treatmentPlanID }">
 				
 				<div>
 					<h3>Add a Predefined Task</h3>
@@ -60,6 +61,7 @@
 			<input type="hidden" name="path" value="${path }">
 			<input type="hidden" name="stageID" value="${stage.stageID }">
 			<input type="hidden" name="isTemplate" value="${task.template }">
+			<input type="hidden" name="treatmentPlanID" value="${treatmentPlanID }">
 				
 			<div class="form-group">
 	            <label for="taskTypeID" class="col-sm-2 control-label">Task Type</label>
@@ -79,10 +81,10 @@
 			<input type="hidden" name="path" value="${path }">
 			<input type="hidden" name="stageID" value="${stage.stageID }">
 			<input type="hidden" name="taskTypeID" value="${task.taskTypeID }">
-			
 			<input type="hidden" name="parentTaskID" value="${task.parentTaskID }">
 			<input type="hidden" name="isTemplate" value="${task.template }">
 			<input type="hidden" name="isExtraTask" value="${task.extraTask }">
+			<input type="hidden" name="treatmentPlanID" value="${treatmentPlanID }">
 			    
 			<c:if test="${task.taskTypeID!=0 }">	
 	        <div class="form-group">

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-edit.jsp
@@ -41,7 +41,7 @@
 	    <label for="taskTypeID" class="col-sm-2 control-label">Task Type</label>
 	    <div class="col-sm-10">
 	        <select class="form-control" id="taskTypeID" name="taskTypeID">
-	            <option  value="">Select a default treatment issue.</option>
+	            <option  value="">Select a task type.</option>
 	            <c:forEach items="${taskTypeMap}" var="taskType">
 	                <option value="${taskType.key}" <c:if test="${taskType.key == task.taskTypeID}">selected</c:if> >${fn:escapeXml(taskType.value)}</option>
 	            </c:forEach>

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-edit.jsp
@@ -60,7 +60,7 @@
 		<input type="hidden" name="isTemplate" value="${task.template }">
 		<input type="hidden" name="isExtraTask" value="${task.extraTask }">
 		<input type="hidden" name="taskOrder" value="${task.taskOrder }">
-		
+		<input type="hidden" name="stageToReturnTo" value="${stageToReturnTo }">
 				
         <div class="form-group">
             <label for="taskTitle" class="col-sm-2 control-label">Task Name</label>

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-edit.jsp
@@ -16,7 +16,7 @@
 	<input type="hidden" name="requestedAction" value="edit-task-select-task">
 	<input type="hidden" name="path" value="${path }">
 
-	<c:if test="${path=='editingTaskTemplate'}">
+	<c:if test="${path=='taskTemplate'}">
 		<div class="form-group">
 			<label for="defaultTaskListID" class="col-sm-2 control-label">Select Task</label>
 			<div class="col-sm-8">

--- a/WebContent/WEB-INF/jsp/treatment-plans/task-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/task-edit.jsp
@@ -61,6 +61,7 @@
 		<input type="hidden" name="isExtraTask" value="${task.extraTask }">
 		<input type="hidden" name="taskOrder" value="${task.taskOrder }">
 		<input type="hidden" name="stageToReturnTo" value="${stageToReturnTo }">
+		<input type="hidden" name="treatmentPlanID" value="${treatmentPlanID }">
 				
         <div class="form-group">
             <label for="taskTitle" class="col-sm-2 control-label">Task Name</label>

--- a/WebContent/WEB-INF/jsp/treatment-plans/treatment-plan-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/treatment-plan-edit.jsp
@@ -21,7 +21,7 @@
 <c:import url="/WEB-INF/jsp/message-modal.jsp" />
 
 
-<c:if test="${path=='editingPlan' || path=='editingPlanTemplate' }">
+<c:if test="${path=='treatmentPlanTemplate' }">
 <div class="row">
 	<div class="form-group">
 		<form class="form-horizontal" action="/secure/EditTreatmentPlan" method="POST">
@@ -46,7 +46,7 @@
 		<div class="col-xs-1">
 			<form class="form-horizontal" action="/secure/CreateTreatmentPlan" method="POST">
 				<input type="hidden" name="requestedAction" value="plan-create-start"> 
-				<input type="hidden" name="path" value="creatingPlanTemplate">
+				<input type="hidden" name="path" value="treatmentPlanTemplate">
 				<button type="submit" class="btn btn-default glyphicon glyphicon-plus" aria-hidden="true" title="Add a new treatment plan."></button>
 			</form>
 		</div>	

--- a/WebContent/WEB-INF/jsp/treatment-plans/treatment-plan-edit.jsp
+++ b/WebContent/WEB-INF/jsp/treatment-plans/treatment-plan-edit.jsp
@@ -201,7 +201,7 @@
 							<c:forEach items="${stage.tasks }" var="task">
 								<tr>
 									<!-- <th scope="row">${task.taskOrder}</th>-->
-									<td><c:out value="${fn:escapeXml(task.title) }"></c:out><span
+									<td>${task.title} (${task.repetitions }) <span
 										class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
 										<!-- <a role="button"
 										href="/secure/EditTask?requestedAction=edit-task-select-task&path=${path}&treatmentPlanID=${treatmentPlan.treatmentPlanID}&stageID=${stage.stageID}&taskID=${task.taskID}"

--- a/src/com/cggcoding/controllers/client/ClientSelectPlan.java
+++ b/src/com/cggcoding/controllers/client/ClientSelectPlan.java
@@ -76,7 +76,9 @@ public class ClientSelectPlan extends HttpServlet {
 					case "select-plan-load":
 						int assignedTreatmentPlanID = ParameterUtils.parseIntParameter(request, "selectedPlanID");
 						TreatmentPlan selectedPlan = TreatmentPlan.load(assignedTreatmentPlanID);
-						selectedPlan.initialize();
+						if(request.getParameter("initialize").equals("yes")){
+							selectedPlan.initialize();
+						}
 						
 						client.setActiveTreatmentPlanId(assignedTreatmentPlanID);
 						

--- a/src/com/cggcoding/controllers/treatmentplan/CreateStage.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateStage.java
@@ -69,6 +69,9 @@ public class CreateStage extends HttpServlet {
 		TreatmentPlan treatmentPlan = null;
 		List<Stage> defaultStages = null;
 		
+		//maintain treatmentPlanID for when wanting to return user to main edit plan page
+		request.setAttribute("treatmentPlanID", treatmentPlanID);
+		
 		try{
 			
 			defaultStages = Stage.getDefaultStages();
@@ -112,8 +115,12 @@ public class CreateStage extends HttpServlet {
 		                if(path.equals("stageTemplate")){
 		                	newStage = Stage.createTemplate(userAdmin.getUserID(), stageTitle, stageDescription);
 		                } else {
+		                	newStage = Stage.createTemplate(userAdmin.getUserID(), stageTitle, stageDescription);
 		                	treatmentPlan = TreatmentPlan.load(treatmentPlanID);
-		                	newStage = treatmentPlan.createNewStage(userAdmin.getUserID(), stageTitle, stageDescription);
+		                	treatmentPlan.addStageTemplate(newStage.getStageID());
+		                	
+		                	/*treatmentPlan = TreatmentPlan.load(treatmentPlanID);
+		                	newStage = treatmentPlan.createNewStage(userAdmin.getUserID(), stageTitle, stageDescription);*/
 		                }
 
 		                request.setAttribute("stage", newStage);

--- a/src/com/cggcoding/controllers/treatmentplan/CreateStage.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateStage.java
@@ -81,17 +81,23 @@ public class CreateStage extends HttpServlet {
 
 						forwardTo = "/WEB-INF/jsp/treatment-plans/stage-create.jsp";
 						break;
-					case "stage-add-default": //default stage can never be a template, so it will always call treatmentPlan.copyStageIntoPlan()
+					case "stage-add-default-template":
 						
 						if(selectedDefaultStageID != 0){
 							treatmentPlan = TreatmentPlan.load(treatmentPlanID);
-							treatmentPlan.copyStageIntoTreatmentPlan(selectedDefaultStageID);
+							treatmentPlan.addStageTemplate(selectedDefaultStageID);
+							//treatmentPlan.copyStageIntoTreatmentPlan(selectedDefaultStageID);
 	
 			            	if(path.equals("treatmentPlanTemplate")){
 			                	request.setAttribute("successMessage", SuccessMessages.STAGE_ADDED_TO_TREATMENT_PLAN);
 			                	
 			                	//freshly load the treatment plan so it has the newly created stage included when returning to the edit plan page
 			                	CommonServletFunctions.setDefaultTreatmentIssuesInRequest(request);
+			                	CommonServletFunctions.setDefaultTreatmentPlansInRequest(request);
+			                	
+			                	//OPTIMIZE loading the plan twice here - possible improvement would be to have plan.addStageTemplate add the stage to the local stages List so would need to have the dao method return a stage 
+			                	//need to reload the plan with the newly added stage
+			                	treatmentPlan = TreatmentPlan.load(treatmentPlanID);
 			                	forwardTo = "/WEB-INF/jsp/treatment-plans/treatment-plan-edit.jsp";
 			                }
 						}

--- a/src/com/cggcoding/controllers/treatmentplan/CreateStage.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateStage.java
@@ -40,35 +40,6 @@ public class CreateStage extends HttpServlet {
 	 */
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		processRequest(request, response);
-		/*--Common Servlet variables that should be in every controller--*/
-		/*HttpSession session = request.getSession();
-		User user = (User)session.getAttribute("user");
-		String forwardTo = "index.jsp";
-		String requestedAction = request.getParameter("requestedAction");
-		String path = request.getParameter("path");
-		request.setAttribute("path", path);
-		-----------End Common Servlet variables---------------
-		
-		if(user.hasRole("admin")){
-			int treatmentPlanID = ParameterUtils.parseIntParameter(request, "treatmentPlanID");
-
-			try {
-				switch(requestedAction){
-				case("add-stage-to-treatment-plan"):
-					//set all user-independent lists into request
-					request.setAttribute("defaultStages", DefaultDatabaseCalls.getDefaultStages());
-					request.setAttribute("treatmentPlan", TreatmentPlan.load(treatmentPlanID));
-					break;
-				}
-				
-			} catch (DatabaseException | ValidationException e) {
-				request.setAttribute("errorMessage", e.getMessage());
-				e.printStackTrace();
-			}
-			
-			
-			request.getRequestDispatcher("/WEB-INF/jsp/treatment-plans/stage-create.jsp").forward(request, response);
-		}*/
 	}
 
 	/**
@@ -116,7 +87,7 @@ public class CreateStage extends HttpServlet {
 							treatmentPlan = TreatmentPlan.load(treatmentPlanID);
 							treatmentPlan.copyStageIntoTreatmentPlan(selectedDefaultStageID);
 	
-			            	if(path.equals("editingPlanTemplate") || path.equals("creatingPlanTemplate")){
+			            	if(path.equals("treatmentPlanTemplate")){
 			                	request.setAttribute("successMessage", SuccessMessages.STAGE_ADDED_TO_TREATMENT_PLAN);
 			                	
 			                	//freshly load the treatment plan so it has the newly created stage included when returning to the edit plan page
@@ -132,7 +103,7 @@ public class CreateStage extends HttpServlet {
 		                }
 		                
 		                Stage newStage = null;
-		                if(path.equals("creatingStageTemplate")){
+		                if(path.equals("stageTemplate")){
 		                	newStage = Stage.createTemplate(userAdmin.getUserID(), stageTitle, stageDescription);
 		                } else {
 		                	treatmentPlan = TreatmentPlan.load(treatmentPlanID);
@@ -142,7 +113,7 @@ public class CreateStage extends HttpServlet {
 		                request.setAttribute("stage", newStage);
 		                
 		                
-		                if(path.equals("editingPlanTemplate")){
+		                if(path.equals("treatmentPlanTemplate")){
 		                	
 		                	request.setAttribute("successMessage", SuccessMessages.STAGE_ADDED_TO_TREATMENT_PLAN);
 		                }else{

--- a/src/com/cggcoding/controllers/treatmentplan/CreateStage.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateStage.java
@@ -73,6 +73,9 @@ public class CreateStage extends HttpServlet {
 		request.setAttribute("treatmentPlanID", treatmentPlanID);
 		
 		try{
+			if(!path.equals("stageTemplate")){
+				treatmentPlan = TreatmentPlan.load(treatmentPlanID);
+			}
 			
 			defaultStages = Stage.getDefaultStages();
 			
@@ -87,7 +90,7 @@ public class CreateStage extends HttpServlet {
 					case "stage-add-default-template":
 						
 						if(selectedDefaultStageID != 0){
-							treatmentPlan = TreatmentPlan.load(treatmentPlanID);
+							//TODO delete? treatmentPlan = TreatmentPlan.load(treatmentPlanID);
 							treatmentPlan.addStageTemplate(selectedDefaultStageID);
 							//treatmentPlan.copyStageIntoTreatmentPlan(selectedDefaultStageID);
 	
@@ -116,7 +119,7 @@ public class CreateStage extends HttpServlet {
 		                	newStage = Stage.createTemplate(userAdmin.getUserID(), stageTitle, stageDescription);
 		                } else {
 		                	newStage = Stage.createTemplate(userAdmin.getUserID(), stageTitle, stageDescription);
-		                	treatmentPlan = TreatmentPlan.load(treatmentPlanID);
+		                	//TODO delete? treatmentPlan = TreatmentPlan.load(treatmentPlanID);
 		                	treatmentPlan.addStageTemplate(newStage.getStageID());
 		                	
 		                	/*treatmentPlan = TreatmentPlan.load(treatmentPlanID);
@@ -137,7 +140,7 @@ public class CreateStage extends HttpServlet {
 		            case("add-stage-to-treatment-plan"):
 						//set all user-independent lists into request
 						request.setAttribute("defaultStages", defaultStages);
-						treatmentPlan = TreatmentPlan.load(treatmentPlanID);
+		            	//TODO delete? treatmentPlan = TreatmentPlan.load(treatmentPlanID);
 						forwardTo = "/WEB-INF/jsp/treatment-plans/stage-create.jsp";
 						break;
 		            default:

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
@@ -76,11 +76,12 @@ public class CreateTask extends HttpServlet {
 					request.setAttribute("task", taskToCreate);
 					forwardTo = "/WEB-INF/jsp/treatment-plans/task-create.jsp";
 					break;
-				case "task-add-default" :
+				case "task-add-default-template" :
 
 					if(taskToCreate.getTaskID() != 0){
 						stage = Stage.load(stageID);
-						stage.copyTaskIntoStage(taskToCreate.getTaskID());
+						stage.addTaskTemplate(taskToCreate.getTaskID());
+						//stage.copyTaskIntoStage(taskToCreate.getTaskID());
 						
 						if(path.equals("treatmentPlanTemplate") || path.equals("stageTemplate")){
 							request.setAttribute("stage", stage);

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
@@ -35,16 +35,7 @@ public class CreateTask extends HttpServlet {
 	/**
 	 * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
 	 */
-	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		/*--Common Servlet variables that should be in every controller--*/
-		/*HttpSession session = request.getSession();
-		User user = (User)session.getAttribute("user");
-		String forwardTo = "index.jsp";
-		String requestedAction = request.getParameter("requestedAction");
-		String path = request.getParameter("path");
-		request.setAttribute("path", path);*/
-		/*-----------End Common Servlet variables---------------*/
-		
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {		
 		processRequest(request, response);
 	}
 
@@ -91,7 +82,7 @@ public class CreateTask extends HttpServlet {
 						stage = Stage.load(stageID);
 						stage.copyTaskIntoStage(taskToCreate.getTaskID());
 						
-						if(path.equals("editingPlanTemplate") || path.equals("creatingPlanTemplate") || path.equals("creatingStageTemplate")|| path.equals("editingStageTemplate")){
+						if(path.equals("treatmentPlanTemplate") || path.equals("stageTemplate")){
 							request.setAttribute("stage", stage);
 							request.setAttribute("defaultStageList", Stage.getDefaultStages());
 							forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";
@@ -106,8 +97,20 @@ public class CreateTask extends HttpServlet {
 					request.setAttribute("defaultTasks", Task.getDefaultTasks());
 					forwardTo = "/WEB-INF/jsp/treatment-plans/task-create.jsp";
 					break;
-				case ("new-task-save"):
-					if(path.equals("creatingTaskTemplate")){
+				case ("create-new-task"):
+					//TODO implement this?
+					switch(path){
+						case "taskTemplate":
+							
+							break;
+						case "stageTemplate":
+							
+							break;
+						default:
+							
+							
+					}
+					if(path.equals("taskTemplate")){
 						Task.createTemplate(taskToCreate);
 					} else{
 						stage = Stage.load(stageID);
@@ -121,7 +124,7 @@ public class CreateTask extends HttpServlet {
 						request.setAttribute("stage", Stage.load(stageID));
 					}
 										
-					if(path.equals("editingPlanTemplate") || path.equals("creatingPlanTemplate") || path.equals("creatingStageTemplate")|| path.equals("editingStageTemplate")){
+					if(path.equals("treatmentPlanTemplate") || path.equals("stageTemplate")){
 						forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";
 					}else{
 						forwardTo = "/WEB-INF/jsp/admin-tools/admin-main-menu.jsp";
@@ -131,7 +134,7 @@ public class CreateTask extends HttpServlet {
 				}
 				
 				
-				if(path.equals("creatingTaskTemplate")){
+				if(path.equals("taskTemplate")){
 					
 				}else{
 					stage = getStageAndPutInRequest(request, stageID);

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
@@ -84,7 +84,7 @@ public class CreateTask extends HttpServlet {
 						//stage.copyTaskIntoStage(taskToCreate.getTaskID());
 						
 						if(path.equals("treatmentPlanTemplate") || path.equals("stageTemplate")){
-							request.setAttribute("stage", stage);
+							request.setAttribute("stage", stage);//XXX right now this is redundant as loadStageAndPutInRequest is called later
 							request.setAttribute("defaultStageList", Stage.getDefaultStages());
 							forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";
 						}else{
@@ -138,7 +138,7 @@ public class CreateTask extends HttpServlet {
 				if(path.equals("taskTemplate")){
 					
 				}else{
-					stage = getStageAndPutInRequest(request, stageID);
+					stage = loadStageAndPutInRequest(request, stageID);
 				}
 
 			}
@@ -155,7 +155,7 @@ public class CreateTask extends HttpServlet {
 		request.getRequestDispatcher(forwardTo).forward(request, response);
 	}
 	
-	private Stage getStageAndPutInRequest(HttpServletRequest request, int stageID) throws DatabaseException, ValidationException{
+	private Stage loadStageAndPutInRequest(HttpServletRequest request, int stageID) throws DatabaseException, ValidationException{
 		Stage stage = null;
 		if(stageID != 0){
 			stage = Stage.load(stageID);

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
@@ -12,6 +12,7 @@ import com.cggcoding.exceptions.DatabaseException;
 import com.cggcoding.exceptions.ValidationException;
 import com.cggcoding.models.Stage;
 import com.cggcoding.models.Task;
+import com.cggcoding.models.TreatmentPlan;
 import com.cggcoding.models.User;
 import com.cggcoding.models.UserAdmin;
 import com.cggcoding.utils.CommonServletFunctions;
@@ -70,6 +71,10 @@ public class CreateTask extends HttpServlet {
 			//put user-independent (i.e. default) lists acquired from database in the request
 			request.setAttribute("taskTypeMap", Task.getTaskTypeMap());
 			request.setAttribute("defaultTasks", Task.getDefaultTasks());
+			
+			if(!path.equals("taskTemplate")){
+				stage = Stage.load(stageID);
+			}
 	
 			if(user.hasRole("admin")){
 				UserAdmin admin = (UserAdmin)user;
@@ -82,7 +87,7 @@ public class CreateTask extends HttpServlet {
 				case "task-add-default-template" :
 
 					if(taskToCreate.getTaskID() != 0){
-						stage = Stage.load(stageID);
+						//TODO delete? stage = Stage.load(stageID);
 						stage.addTaskTemplate(taskToCreate.getTaskID());
 						//stage.copyTaskIntoStage(taskToCreate.getTaskID());
 						
@@ -122,7 +127,7 @@ public class CreateTask extends HttpServlet {
 						Task.createTemplate(taskToCreate);
 					} else {
 						newTask = Task.createTemplate(taskToCreate);
-						stage = Stage.load(stageID);
+						//TODO delete? stage = Stage.load(stageID);
 						stage.addTaskTemplate(newTask.getTaskID());
 						/*stage = Stage.load(stageID);
 						stage.createNewTask(taskToCreate);

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
@@ -63,6 +63,9 @@ public class CreateTask extends HttpServlet {
 		//performed here to get parameters for all tasks run below depending on what type of task is selected
 		Task taskToCreate = CommonServletFunctions.getTaskParametersFromRequest(request, userID);
 
+		int planToReturnTo = ParameterUtils.parseIntParameter(request, "treatmentPlanID");
+		request.setAttribute("treatmentPlanID", planToReturnTo);
+		
 		try {
 			//put user-independent (i.e. default) lists acquired from database in the request
 			request.setAttribute("taskTypeMap", Task.getTaskTypeMap());

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
@@ -106,7 +106,7 @@ public class CreateTask extends HttpServlet {
 					request.setAttribute("defaultTasks", Task.getDefaultTasks());
 					forwardTo = "/WEB-INF/jsp/treatment-plans/task-create.jsp";
 					break;
-				case ("task-save"):
+				case ("new-task-save"):
 					if(path.equals("creatingTaskTemplate")){
 						Task.createTemplate(taskToCreate);
 					} else{

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
@@ -157,6 +157,7 @@ public class CreateTask extends HttpServlet {
 			//put in temporary task object so values can be saved in inputs after error
 			request.setAttribute("stage", stage);
 			request.setAttribute("task", taskToCreate);
+			request.setAttribute("treatmentPlanID", planToReturnTo);
 			request.setAttribute("errorMessage", e.getMessage());
 
 			forwardTo = "/WEB-INF/jsp/treatment-plans/task-create.jsp";

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTask.java
@@ -102,28 +102,35 @@ public class CreateTask extends HttpServlet {
 					forwardTo = "/WEB-INF/jsp/treatment-plans/task-create.jsp";
 					break;
 				case ("create-new-task"):
+					Task newTask = null;
+				
 					//TODO implement this?
-					switch(path){
+					/*switch(path){
 						case "taskTemplate":
-							
+							Task.createTemplate(taskToCreate);
 							break;
 						case "stageTemplate":
-							
+							newTask = Task.createTemplate(taskToCreate);
+							stage = Stage.load(stageID);
+							stage.addTaskTemplate(newTask.getTaskID());
 							break;
 						default:
 							
 							
-					}
+					}*/
 					if(path.equals("taskTemplate")){
 						Task.createTemplate(taskToCreate);
-					} else{
+					} else {
+						newTask = Task.createTemplate(taskToCreate);
 						stage = Stage.load(stageID);
+						stage.addTaskTemplate(newTask.getTaskID());
+						/*stage = Stage.load(stageID);
 						stage.createNewTask(taskToCreate);
 						
 						if(ParameterUtils.singleCheckboxIsOn(request, "copyAsTemplate")){
 							Task templateCopy = taskToCreate.copy();
 							Task.createTemplate(templateCopy);
-						}
+						}*/
 						
 						request.setAttribute("stage", Stage.load(stageID));
 					}

--- a/src/com/cggcoding/controllers/treatmentplan/CreateTreatmentPlan.java
+++ b/src/com/cggcoding/controllers/treatmentplan/CreateTreatmentPlan.java
@@ -109,7 +109,7 @@ public class CreateTreatmentPlan extends HttpServlet implements Serializable{
 
 		                treatmentPlan = TreatmentPlan.getInstanceWithoutID(planTitle, user.getUserID(), planDescription, treatmentIssueID);
 		                
-		                if(path.equals("creatingPlanTemplate")){
+		                if(path.equals("treatmentPlanTemplate")){
 		                	treatmentPlan.setTemplate(true);
 		                }else{
 		                	treatmentPlan.setTemplate(false);

--- a/src/com/cggcoding/controllers/treatmentplan/EditStage.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditStage.java
@@ -19,6 +19,7 @@ import com.cggcoding.models.UserAdmin;
 import com.cggcoding.utils.CommonServletFunctions;
 import com.cggcoding.utils.ParameterUtils;
 import com.cggcoding.utils.messaging.SuccessMessages;
+import com.cggcoding.utils.messaging.WarningMessages;
 
 /**
  * Servlet implementation class EditStage
@@ -63,7 +64,13 @@ public class EditStage extends HttpServlet {
 		String stageTitle = request.getParameter("stageTitle");
 		String stageDescription = request.getParameter("stageDescription");
 		Stage editedStage = null;
-		
+		int treatmentPlanID = ParameterUtils.parseIntParameter(request, "treatmentPlanID");
+		/*This variable helps remember where to send the user back to when they are done editing the Task.
+		If the Task being edited is a template the stageID will be TEMPLATE_HOLDER_ID, and not the Stage template being working on.
+		If the Task being edited is part of a client's plan, then the stageID will be the stageID that is contained within the task.
+		Need to maintain it between requests*/
+		int planToReturnTo = treatmentPlanID;
+		request.setAttribute("treatmentPlanID", planToReturnTo);
 		
 		try{
 			request.setAttribute("defaultStageList", Stage.getDefaultStages());
@@ -83,6 +90,10 @@ public class EditStage extends HttpServlet {
 		            		request.setAttribute("stage", null);
 		            	}
 		            	
+		            	if(path.equals("treatmentPlanTemplate")){
+							request.setAttribute("warningMessage", WarningMessages.EDITING_STAGE_TEMPLATE);
+						}
+		            	
 		            	forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";
 		            	break;
 		            case "stage-edit-name" :
@@ -99,7 +110,7 @@ public class EditStage extends HttpServlet {
 		            	request.setAttribute("stage", editedStage);
 		            	if(path.equals("treatmentPlanTemplate")){
 		            		request.setAttribute("successMessage", SuccessMessages.STAGE_UPDATED);
-		            		request.setAttribute("treatmentPlan", TreatmentPlan.load(editedStage.getTreatmentPlanID()));
+		            		request.setAttribute("treatmentPlan", TreatmentPlan.load(planToReturnTo));
 		            		request.setAttribute("defaultTreatmentIssues", TreatmentIssue.getDefaultTreatmentIssues());
 		            		CommonServletFunctions.setDefaultTreatmentPlansInRequest(request);
 		            		forwardTo = "/WEB-INF/jsp/treatment-plans/treatment-plan-edit.jsp";
@@ -116,10 +127,16 @@ public class EditStage extends HttpServlet {
 		            	request.setAttribute("stage", Stage.load(stageID));
 		            	forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";
 		            	break;
-		            	
+		            
+		            //TODO remove this and have calling forms use stage-edit-select-stage instead
 		            case "stage-edit":
 						editedStage = Stage.load(stageID);
 						request.setAttribute("stage", editedStage);
+						
+						if(path.equals("treatmentPlanTemplate")){
+							request.setAttribute("warningMessage", WarningMessages.EDITING_STAGE_TEMPLATE);
+						}
+						
 						forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";
 						break;	
 						
@@ -153,6 +170,7 @@ public class EditStage extends HttpServlet {
 			request.setAttribute("stage", editedStage);
 			request.setAttribute("stageTitle", stageTitle);
 			request.setAttribute("stageDescription", stageDescription);
+			request.setAttribute("treatmentPlanID", planToReturnTo);
             forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";
 		}
 		

--- a/src/com/cggcoding/controllers/treatmentplan/EditStage.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditStage.java
@@ -18,6 +18,7 @@ import com.cggcoding.models.User;
 import com.cggcoding.models.UserAdmin;
 import com.cggcoding.utils.CommonServletFunctions;
 import com.cggcoding.utils.ParameterUtils;
+import com.cggcoding.utils.messaging.ErrorMessages;
 import com.cggcoding.utils.messaging.SuccessMessages;
 import com.cggcoding.utils.messaging.WarningMessages;
 
@@ -97,6 +98,9 @@ public class EditStage extends HttpServlet {
 		            	forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";
 		            	break;
 		            case "stage-edit-name" :
+		            	if(stageID==0){
+		            		throw new ValidationException(ErrorMessages.NOTHING_SELECTED);
+		            	}
 		            	editedStage = Stage.load(stageID);
 		            	editedStage.setTitle(stageTitle);
 		            	editedStage.setDescription(stageDescription);

--- a/src/com/cggcoding/controllers/treatmentplan/EditStage.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditStage.java
@@ -16,6 +16,7 @@ import com.cggcoding.models.TreatmentIssue;
 import com.cggcoding.models.TreatmentPlan;
 import com.cggcoding.models.User;
 import com.cggcoding.models.UserAdmin;
+import com.cggcoding.utils.CommonServletFunctions;
 import com.cggcoding.utils.ParameterUtils;
 import com.cggcoding.utils.messaging.SuccessMessages;
 
@@ -96,10 +97,11 @@ public class EditStage extends HttpServlet {
 		            	editedStage.update();
 		            	
 		            	request.setAttribute("stage", editedStage);
-		            	if(path.equals("editingPlanTemplate") || path.equals("creatingPlanTemplate")){
+		            	if(path.equals("treatmentPlanTemplate")){
 		            		request.setAttribute("successMessage", SuccessMessages.STAGE_UPDATED);
 		            		request.setAttribute("treatmentPlan", TreatmentPlan.load(editedStage.getTreatmentPlanID()));
 		            		request.setAttribute("defaultTreatmentIssues", TreatmentIssue.getDefaultTreatmentIssues());
+		            		CommonServletFunctions.setDefaultTreatmentPlansInRequest(request);
 		            		forwardTo = "/WEB-INF/jsp/treatment-plans/treatment-plan-edit.jsp";
 		            	}else{
 		            		request.setAttribute("successMessage", SuccessMessages.STAGE_UPDATED);

--- a/src/com/cggcoding/controllers/treatmentplan/EditTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditTask.java
@@ -125,6 +125,7 @@ public class EditTask extends HttpServlet {
 			//put in temporary task object so values can be saved in inputs after error
 			request.setAttribute("task", tempTask);
 			request.setAttribute("stageToReturnTo", stageToReturnTo);
+			request.setAttribute("treatmentPlanID", planToReturnTo);
 			request.setAttribute("errorMessage", e.getMessage());
 
 			forwardTo = "/WEB-INF/jsp/treatment-plans/task-edit.jsp";

--- a/src/com/cggcoding/controllers/treatmentplan/EditTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditTask.java
@@ -57,18 +57,18 @@ public class EditTask extends HttpServlet {
 		/*-----------End Common Servlet variables---------------*/
 		
 		userID =  user.getUserID();
-		
-		/*This variable helps remember where to send the user back to when they are done editing the Task.
-		If the Task being edited is a template the stageID will be TEMPLATE_HOLDER_ID, and not the Stage template being working on.
-		If the Task being edited is part of a client's plan, then the stageID will be the stageID that is contained within the task.
-		*/
-		int stageToReturnTo = 0;
-		
-		
+
 		//performed here to get parameters for all tasks run below
 		Task tempTask = CommonServletFunctions.getTaskParametersFromRequest(request, userID);
 		
-		
+		/*These variables helps remember where to send the user back to when they are done editing the Task.
+		If the Task being edited is a template the stageID will be TEMPLATE_HOLDER_ID, and not the Stage template being working on.
+		If the Task being edited is part of a client's plan, then the stageID will be the stageID that is contained within the task.
+		Need to maintain it between requests*/
+		int stageToReturnTo = tempTask.getStageID();
+		request.setAttribute("stageToReturnTo", stageToReturnTo);
+		int planToReturnTo = ParameterUtils.parseIntParameter(request, "treatmentPlanID");
+		request.setAttribute("treatmentPlanID", planToReturnTo);
 
 		try {
 			//put user-independent attributes acquired from database in the request
@@ -82,20 +82,12 @@ public class EditTask extends HttpServlet {
 					//set tempTask in request so page knows value of isTemplate
 					request.setAttribute("task", tempTask);
 					
-					//
-					stageToReturnTo = tempTask.getStageID();
-					request.setAttribute("stageToReturnTo", stageToReturnTo);
-					
 					forwardTo = "/WEB-INF/jsp/treatment-plans/task-edit.jsp";
 					break;
 				case ("edit-task-select-task"):
 					int selectedTaskID = ParameterUtils.parseIntParameter(request, "taskID");
 					
 					request.setAttribute("task", Task.load(selectedTaskID));
-					
-					//maintain stageToReturnTo
-					stageToReturnTo = tempTask.getStageID();
-					request.setAttribute("stageToReturnTo", stageToReturnTo);
 					
 					if(path.equals("treatmentPlanTemplate")|| path.equals("stageTemplate")){
 						request.setAttribute("warningMessage", WarningMessages.EDITING_TASK_TEMPLATE);
@@ -105,6 +97,8 @@ public class EditTask extends HttpServlet {
 					break;
 				case ("edit-task-select-task-type"):
 					// most of the work for this case was moved to CommonServletFunctions.getTaskParametersFromRequest, so now it just needs to set forwardTo
+					
+					
 					
 					forwardTo = "/WEB-INF/jsp/treatment-plans/task-edit.jsp";
 					break;

--- a/src/com/cggcoding/controllers/treatmentplan/EditTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditTask.java
@@ -35,44 +35,7 @@ public class EditTask extends HttpServlet {
 	 * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
 	 */
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		
 		processRequest(request, response);
-		
-		/*--Common Servlet variables that should be in every controller--*/
-		/*HttpSession session = request.getSession();
-		User user = (User)session.getAttribute("user");
-		String forwardTo = "index.jsp";
-		String requestedAction = request.getParameter("requestedAction");
-		String path = request.getParameter("path");
-		request.setAttribute("path", path);*/
-		/*-----------End Common Servlet variables---------------*/
-		
-		/*int taskID = ParameterUtils.parseIntParameter(request, "taskID");
-		
-		try {
-			if(user.isAuthorizedForTask(taskID)){
-				if(user.hasRole("admin")){
-					switch(requestedAction){
-					case ("edit-task-select-task"):
-						int selectedTaskID = ParameterUtils.parseIntParameter(request, "taskID");
-	
-						
-							Task tempTask = Task.load(selectedTaskID);
-							request.setAttribute("task", tempTask);
-						
-						forwardTo = "/WEB-INF/jsp/treatment-plans/task-edit.jsp";
-						break;
-					}
-				}
-			}
-		} catch (DatabaseException e) {
-			//request.setAttribute("task", tempTask);
-			request.setAttribute("errorMessage", e.getMessage());
-
-			forwardTo = "/WEB-INF/jsp/treatment-plans/task-edit.jsp";
-		}
-		
-		request.getRequestDispatcher(forwardTo).forward(request, response);*/
 	}
 
 	/**
@@ -134,7 +97,7 @@ public class EditTask extends HttpServlet {
 					
 					tempTask.update();
 					
-					if(path.equals("editingPlanTemplate") || path.equals("creatingPlanTemplate") || path.equals("creatingStageTemplate")|| path.equals("editingStageTemplate")){
+					if(path.equals("treatmentPlanTemplate")|| path.equals("stageTemplate")){
 						request.setAttribute("stage", Stage.load(tempTask.getStageID()));
 						request.setAttribute("defaultStageList", Stage.getDefaultStages());
 						forwardTo = "/WEB-INF/jsp/treatment-plans/stage-edit.jsp";

--- a/src/com/cggcoding/controllers/treatmentplan/EditTask.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditTask.java
@@ -15,6 +15,7 @@ import com.cggcoding.models.Task;
 import com.cggcoding.models.User;
 import com.cggcoding.utils.CommonServletFunctions;
 import com.cggcoding.utils.ParameterUtils;
+import com.cggcoding.utils.messaging.ErrorMessages;
 import com.cggcoding.utils.messaging.WarningMessages;
 
 /**
@@ -103,7 +104,9 @@ public class EditTask extends HttpServlet {
 					forwardTo = "/WEB-INF/jsp/treatment-plans/task-edit.jsp";
 					break;
 				case ("edit-task-update"):
-					
+					if(tempTask.getTaskID()==0){
+						throw new ValidationException(ErrorMessages.NOTHING_SELECTED);
+					}
 					tempTask.update();
 					
 					stageToReturnTo = ParameterUtils.parseIntParameter(request, "stageToReturnTo");

--- a/src/com/cggcoding/controllers/treatmentplan/EditTreatmentPlan.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditTreatmentPlan.java
@@ -180,8 +180,8 @@ public class EditTreatmentPlan extends HttpServlet {
     	} catch (ValidationException | DatabaseException e) {
     		request.setAttribute("errorMessage", e.getMessage());
     		
-    		//create a temporary treatmentPlan to hold info for plan that is in the process of creation
-    		treatmentPlan = TreatmentPlan.getInstanceBasic(ParameterUtils.parseIntParameter(request, "treatmentPlanID"), user.getUserID(), request.getParameter("planTitle"), request.getParameter("planDescription"), 0, false, false, false,0,0);
+    		//create a temporary treatmentPlan to hold title and description info that might be changed for plan that is in the process of creation - UNSURE if this will cause accidental replacement of the other fields that I am just supplying false and 0 to
+    		treatmentPlan = TreatmentPlan.getInstanceBasic(ParameterUtils.parseIntParameter(request, "treatmentPlanID"), user.getUserID(), request.getParameter("planTitle"), request.getParameter("planDescription"), 0, false, false, false,0,0,0);
     		request.setAttribute("treatmentPlan", treatmentPlan);
     		request.setAttribute("defaultTreatmentIssue", defaultIssueID);
     		request.setAttribute("existingCustomTreatmentIssue", customIssueID);

--- a/src/com/cggcoding/controllers/treatmentplan/EditTreatmentPlan.java
+++ b/src/com/cggcoding/controllers/treatmentplan/EditTreatmentPlan.java
@@ -104,6 +104,10 @@ public class EditTreatmentPlan extends HttpServlet {
 		            	break;
 		            case "plan-edit-update":
 
+		            	if(treatmentPlanID==0){
+		            		throw new ValidationException(ErrorMessages.NOTHING_SELECTED);
+		            	}
+		            	
 		                if(planTitle.isEmpty() || planDescription.isEmpty()){
 		                	throw new ValidationException(ErrorMessages.PLAN_MISSING_INFO);
 		                }

--- a/src/com/cggcoding/models/Stage.java
+++ b/src/com/cggcoding/models/Stage.java
@@ -589,6 +589,34 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 
 	}
 	
+	/**Adds a task template to a stage template.  Inserts into taskTemplate-stageTemplate mapping table. Both the Task and Stage must be templates to be valid.
+	 * @param taskTemplateID
+	 * @throws DatabaseException
+	 * @throws ValidationException
+	 */
+	public void addTaskTemplate(int taskTemplateID) throws DatabaseException, ValidationException{
+		Connection cn = null;
+	
+		if(this.isTemplate()){
+			try {
+				
+	        	cn = dao.getConnection();
+	        	if(dao.mapsTaskStageTemplateValidate(cn, taskTemplateID, this.getStageID())){
+	        		dao.mapsTaskStageTemplateCreate(cn, taskTemplateID, this.stageID);
+	        	}
+
+			} catch (SQLException e) {
+				e.printStackTrace();
+				throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			} finally {
+				DbUtils.closeQuietly(cn);
+		    }		
+		}else{
+			throw new ValidationException(ErrorMessages.STAGE_IS_NOT_TEMPLATE);
+		}
+		
+	}
+	
 	public Task copyTaskIntoStage(int taskIDBeingCopied) throws DatabaseException, ValidationException{
 		Task task = Task.load(taskIDBeingCopied);
 		task.setTemplate(false);

--- a/src/com/cggcoding/models/Stage.java
+++ b/src/com/cggcoding/models/Stage.java
@@ -468,7 +468,8 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 			
 			cn.commit();
 			
-        } catch (SQLException e) {
+        } catch (SQLException | ValidationException e) {
+        	e.printStackTrace();
 			try {
 				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
 				cn.rollback();
@@ -476,7 +477,11 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 				System.out.println(ErrorMessages.ROLLBACK_DB_ERROR);
 				e1.printStackTrace();
 			}
-			e.printStackTrace();
+			if(e.getClass().getSimpleName().equals("ValidationException")){
+				throw new ValidationException(e.getMessage());
+			}else if(e.getClass().getSimpleName().equals("DatabaseException")){
+				throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			}
 		} finally {
 			try {
 				cn.setAutoCommit(true);
@@ -710,7 +715,7 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 			}
 
 			cn.commit();
-		} catch (SQLException e) {
+		} catch (SQLException | ValidationException e) {
             e.printStackTrace();
             try {
 				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
@@ -719,7 +724,11 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 				e1.printStackTrace();
 				throw new DatabaseException(ErrorMessages.ROLLBACK_DB_ERROR);
 			}
-            throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+            if(e.getClass().getSimpleName().equals("ValidationException")){
+				throw new ValidationException(e.getMessage());
+			}else if(e.getClass().getSimpleName().equals("DatabaseException")){
+				throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			}
         } finally {
         	try {
 				cn.setAutoCommit(true);

--- a/src/com/cggcoding/models/Stage.java
+++ b/src/com/cggcoding/models/Stage.java
@@ -393,7 +393,9 @@ public class Stage implements Serializable, Completable, DatabaseModel {
         dao.throwValidationExceptionIfTemplateHolderID(stageID);
         
     	stage = dao.stageLoadBasic(cn, stageID);
+    	
     	stage.setGoals(dao.stageLoadGoals(cn, stage.getStageID()));
+    	
     	if(stage.isTemplate()){
     		stage.setTasks(dao.stageLoadTaskTemplates(cn, stageID));
     	}else{

--- a/src/com/cggcoding/models/Stage.java
+++ b/src/com/cggcoding/models/Stage.java
@@ -34,6 +34,7 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 	private List<StageGoal> goals;
 	private boolean inProgress;
 	private boolean template;
+	private int templateID;
 	
 	private static DatabaseActionHandler dao = new MySQLActionHandler();
 
@@ -51,12 +52,13 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 		this.goals = new ArrayList<>();
 		this.inProgress = false;
 		this.template = template;
+		this.templateID = 0;
 	}
 	
 	//Full constructor - asks for every argument stage has
 	private Stage(int stageID, int treatmentPlanID, int userID, String title, String description, int stageOrder,
 			List<Task> tasks, List<Task> extraTasks, boolean completed, double percentComplete, List<StageGoal> goals,
-			boolean inProgress, boolean template) {
+			boolean inProgress, boolean template, int templateID) {
 		this.stageID = stageID;
 		this.treatmentPlanID = treatmentPlanID;
 		this.userID = userID;
@@ -70,6 +72,7 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 		this.goals = goals;
 		this.inProgress = inProgress;
 		this.template = template;
+		this.templateID = templateID;
 	}
 
 	/**Gets a complete instance of Stage and asks for every argument in class
@@ -87,9 +90,9 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 	 * @param template True if this is a Stage template and therefore has no concrete parent TreatmentPlan
 	 * @return Stage object
 	 */
-	public static Stage getInstance(int stageID, int treatmentPlanID, int userID, String title, String description, int stageOrder,
-			List<Task> tasks, List<Task> extraTasks, boolean completed, double percentComplete, List<StageGoal> goals, boolean inProgress, boolean template){
-		return new Stage(stageID, treatmentPlanID, userID, title, description, stageOrder, tasks, extraTasks, completed, percentComplete, goals, inProgress, template);
+	public static Stage getInstance(int stageID, int treatmentPlanID, int userID, String title, String description, int stageOrder, List<Task> tasks, 
+			List<Task> extraTasks, boolean completed, double percentComplete, List<StageGoal> goals, boolean inProgress, boolean template, int templateID){
+		return new Stage(stageID, treatmentPlanID, userID, title, description, stageOrder, tasks, extraTasks, completed, percentComplete, goals, inProgress, template, templateID);
 	}
 	
 	/**For use when creating a new Stage. As such, these are the only parameters that could be available for saving to the database.  
@@ -218,6 +221,14 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 
 	public void setTemplate(boolean template) {
 		this.template = template;
+	}
+	
+	public int getTemplateID() {
+		return templateID;
+	}
+
+	public void setTemplateID(int templateID) {
+		this.templateID = templateID;
 	}
 
 	//Tasks will be displayed in the order in which they are in the List

--- a/src/com/cggcoding/models/Stage.java
+++ b/src/com/cggcoding/models/Stage.java
@@ -350,6 +350,14 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 		return null;
 	}
 
+	/**Loads the stage and all associated Tasks.  Checks if the Stage is a template.  If so, then it's Tasks are also templates and 
+	 * the database loads the Tasks using the task_template_stage_template_mapping table to get the taskIDs to load.  If not a template then it 
+	 * just loads tasks straight from the task_generic table
+	 * @param stageID
+	 * @return
+	 * @throws DatabaseException
+	 * @throws ValidationException
+	 */
 	public static Stage load(int stageID) throws DatabaseException, ValidationException{
 		Connection cn = null;
 		Stage stage = null;
@@ -370,6 +378,15 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 		
 	}
 	
+	/**Loads the stage and all associated Tasks.  Checks if the Stage is a template.  If so, then it's Tasks are also templates and 
+	 * the database loads the Tasks using the task_template_stage_template_mapping table to get the taskIDs to load.  If not a template then it 
+	 * just loads tasks straight from the task_generic table
+	 * @param cn
+	 * @param stageID
+	 * @return
+	 * @throws SQLException
+	 * @throws ValidationException
+	 */
 	public static Stage load(Connection cn, int stageID) throws SQLException, ValidationException{
 		Stage stage = null;
         
@@ -377,7 +394,12 @@ public class Stage implements Serializable, Completable, DatabaseModel {
         
     	stage = dao.stageLoadBasic(cn, stageID);
     	stage.setGoals(dao.stageLoadGoals(cn, stage.getStageID()));
-		stage.setTasks(dao.stageLoadTasks(cn, stage.getStageID()));
+    	if(stage.isTemplate()){
+    		stage.setTasks(dao.stageLoadTaskTemplates(cn, stageID));
+    	}else{
+    		stage.setTasks(dao.stageLoadTasks(cn, stage.getStageID()));
+    	}
+		
 
         
         dao.throwValidationExceptionIfNull(stage);

--- a/src/com/cggcoding/models/Stage.java
+++ b/src/com/cggcoding/models/Stage.java
@@ -460,7 +460,7 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 		return savedStage;*/
 	}
 	
-	public void create(Connection cn) throws ValidationException, SQLException{
+	protected void create(Connection cn) throws ValidationException, SQLException{
 		
 		if(this.title.isEmpty()){
     		throw new ValidationException(ErrorMessages.STAGE_TITLE_DESCRIPTION_MISSING);
@@ -538,7 +538,7 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 		
 	}
 	
-	public void updateBasic(Connection cn) throws ValidationException, SQLException{
+	protected void updateBasic(Connection cn) throws ValidationException, SQLException{
 		if(dao.stageValidateUpdatedTitle(cn, this)){
 			dao.stageUpdateBasic(cn, this);
 		}
@@ -562,7 +562,7 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 		
 	}
 	
-	public void delete(Connection cn) throws SQLException, ValidationException, DatabaseException{      
+	protected void delete(Connection cn) throws SQLException, ValidationException, DatabaseException{      
         dao.throwValidationExceptionIfTemplateHolderID(this.stageID);
         
         dao.stageDelete(cn, this.stageID);
@@ -584,7 +584,7 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 	    }	
 	}
 	
-	public static void delete(Connection cn, int stageID) throws ValidationException, SQLException {
+	protected static void delete(Connection cn, int stageID) throws ValidationException, SQLException {
         	dao.stageDelete(cn, stageID);
 
 	}

--- a/src/com/cggcoding/models/Stage.java
+++ b/src/com/cggcoding/models/Stage.java
@@ -669,13 +669,13 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 		try{
 			cn = dao.getConnection();
 			cn.setAutoCommit(false);
-			
+			Task task = null;
 			//find task and delete from database then remove from local List
 			for(int i = 0; i < tasks.size(); i++){
-				Task task = tasks.get(i);
+				task = tasks.get(i);
 				if(task.getTaskID() == taskToDeleteID){
 					
-					if(isTemplate()){ //UNSURE Does it matter if I check use Task or Stage isTemplate() method here?  Since keeping the tasks as templates when they are part of stage templates, it really shouldn't but I fear I am overlooking something.
+					if(task.isTemplate()){ //UNSURE Does it matter if I check use Task or Stage isTemplate() method here?  Since keeping the tasks as templates when they are part of stage templates, it really shouldn't but I fear I am overlooking something.
 						dao.mapsTaskStageTemplateDelete(cn, taskToDeleteID);
 					}else{
 						task.delete(cn);
@@ -689,12 +689,12 @@ public class Stage implements Serializable, Completable, DatabaseModel {
 			reorderTasks();
 			
 			//update the remaining tasks with their new order value
-			if(isTemplate()){
+			if(task.isTemplate()){
 				updateTaskTemplateList(cn, tasks);
 			}else{
-				//OPTIMIZE Could replace this with method in dao that take List<Task> and loops through updating
-				for(int i=0; i < this.tasks.size(); i++){
-					tasks.get(i).update(cn);
+				//OPTIMIZE Could replace this with method in dao that takes List<Task> and loops through updating
+				for(Task updateTask : tasks){
+					updateTask.update(cn);
 				}
 			}
 

--- a/src/com/cggcoding/models/StageGoal.java
+++ b/src/com/cggcoding/models/StageGoal.java
@@ -119,7 +119,7 @@ public class StageGoal implements Serializable, DatabaseModel{
 		return this;
 	}
 	
-	public StageGoal create(Connection cn) throws ValidationException, SQLException {
+	protected StageGoal create(Connection cn) throws ValidationException, SQLException {
 		if(isValidGoal()){
 			dao.stageGoalCreate(cn, this);
 		}
@@ -147,7 +147,7 @@ public class StageGoal implements Serializable, DatabaseModel{
 		
 	}
 	
-	public void update(Connection cn) throws ValidationException, SQLException {
+	protected void update(Connection cn) throws ValidationException, SQLException {
 		dao.stageGoalUpdate(cn, this);
 	}
 
@@ -169,7 +169,7 @@ public class StageGoal implements Serializable, DatabaseModel{
 		
 	}
 	
-	public void delete(Connection cn) throws ValidationException, SQLException {
+	protected void delete(Connection cn) throws ValidationException, SQLException {
 		dao.stageGoalDelete(cn, this.stageGoalID);	
 	}
 	

--- a/src/com/cggcoding/models/Task.java
+++ b/src/com/cggcoding/models/Task.java
@@ -47,11 +47,11 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 	private static DatabaseActionHandler dao= new MySQLActionHandler();
 	
 	//empty constructor necessary to allow static factory methods in subclasses
-	public Task(){
+	protected Task(){
 	}
 	
 	//basic parent Task that sets properties to defaults
-	public Task(int taskID, int userID) {
+	protected Task(int taskID, int userID) {
 		this.taskID = taskID;
 		this.stageID = 0;
 		this.userID = userID;
@@ -83,7 +83,7 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 	 * @param extraTask
 	 * @param template
 	 */
-	public Task (int stageID, int userID, int taskTypeID, int parentTaskID, String title, String instructions, String resourceLink, int taskOrder, boolean extraTask, boolean template, int templateID, int repetitions){
+	protected Task (int stageID, int userID, int taskTypeID, int parentTaskID, String title, String instructions, String resourceLink, int taskOrder, boolean extraTask, boolean template, int templateID, int repetitions){
 		this.taskID = 0;
 		this.stageID = stageID;
 		this.userID = userID;
@@ -117,7 +117,7 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 	 * @param extraTask
 	 * @param template
 	 */
-	public Task (int taskID, int stageID, int userID, int taskTypeID, int parentTaskID, String title, String instructions, String resourceLink, boolean completed, LocalDateTime dateCompleted, int taskOrder, boolean extraTask, boolean template, int templateID, int repetitions){
+	protected Task (int taskID, int stageID, int userID, int taskTypeID, int parentTaskID, String title, String instructions, String resourceLink, boolean completed, LocalDateTime dateCompleted, int taskOrder, boolean extraTask, boolean template, int templateID, int repetitions){
 		this.taskID = taskID;
 		this.stageID = stageID;
 		this.userID = userID;
@@ -248,7 +248,7 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 	 * @throws ValidationException
 	 * @throws SQLException
 	 */
-	public Task create(Connection cn)throws ValidationException, SQLException{
+	protected Task create(Connection cn)throws ValidationException, SQLException{
 		
 		createGeneralData(cn);
 		createAdditionalData(cn);
@@ -288,7 +288,7 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
         }
 	}
 	
-	public void update(Connection cn) throws ValidationException, SQLException{
+	protected void update(Connection cn) throws ValidationException, SQLException{
 		dao.taskGenericUpdate(cn, this);
 		updateAdditionalData(cn);
 	}
@@ -309,7 +309,7 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 	    }
 	}
 	
-	public void delete(Connection cn) throws SQLException {
+	protected void delete(Connection cn) throws SQLException {
 		dao.taskDelete(cn, this.taskID);
 	}
 	

--- a/src/com/cggcoding/models/Task.java
+++ b/src/com/cggcoding/models/Task.java
@@ -484,6 +484,7 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 		this.taskOrder = taskOrder;
 	}
 	
+	//FIXME currently not being used since linking Stage templates directly to Task templates and Task templates all have an order value of 0. The order for these tasks is stored in the task-stage mapping table.
 	/**Since taskOrder is based off List indexes, it starts with 0.  So for displaying the order to users on the front end, add 1 so
 	 *the order values start with 1.
 	 * @return

--- a/src/com/cggcoding/models/Task.java
+++ b/src/com/cggcoding/models/Task.java
@@ -220,7 +220,7 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 			task = create(cn);
 			
 			cn.commit();
-		} catch (SQLException e) {
+		} catch (SQLException | ValidationException e) {
 			e.printStackTrace();
 			try {
 				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
@@ -229,7 +229,11 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 				e1.printStackTrace();
 				throw new DatabaseException(ErrorMessages.ROLLBACK_DB_ERROR);
 			}
-			throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			if(e.getClass().getSimpleName().equals("ValidationException")){
+				throw new ValidationException(e.getMessage());
+			}else if(e.getClass().getSimpleName().equals("DatabaseException")){
+				throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			}
 		} finally {
 			try {
 				cn.setAutoCommit(true);
@@ -268,7 +272,7 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
         	}
         	cn.commit();
 
-        } catch (SQLException e) {
+        } catch (SQLException | ValidationException e) {
             e.printStackTrace();
             try {
 				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
@@ -277,7 +281,11 @@ public abstract class Task implements Serializable, Completable, DatabaseModel{
 				e1.printStackTrace();
 				throw new DatabaseException(ErrorMessages.ROLLBACK_DB_ERROR);
 			}
-            throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+            if(e.getClass().getSimpleName().equals("ValidationException")){
+				throw new ValidationException(e.getMessage());
+			}else if(e.getClass().getSimpleName().equals("DatabaseException")){
+				throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			}
         } finally {
         	try {
 				cn.setAutoCommit(true);

--- a/src/com/cggcoding/models/TaskGeneric.java
+++ b/src/com/cggcoding/models/TaskGeneric.java
@@ -18,6 +18,9 @@ public class TaskGeneric extends Task implements Serializable{
 	private static final long serialVersionUID = 1L;
 	private static DatabaseActionHandler dao= new MySQLActionHandler();
 	
+	/**
+	 * Default constructor.  Designated public so Task.getTaskType() can be accessed outside of the package.
+	 */
 	public TaskGeneric(){
 		super();
 	}

--- a/src/com/cggcoding/models/TaskTwoTextBoxes.java
+++ b/src/com/cggcoding/models/TaskTwoTextBoxes.java
@@ -24,6 +24,9 @@ public class TaskTwoTextBoxes extends Task implements Serializable{
 	
 	private static DatabaseActionHandler dao = new MySQLActionHandler();
 	
+	/**
+	 * Default constructor.  Designated public so Task.getTaskType() can be accessed outside of the package.
+	 */
 	public TaskTwoTextBoxes(){
 		super();
 	}

--- a/src/com/cggcoding/models/TreatmentPlan.java
+++ b/src/com/cggcoding/models/TreatmentPlan.java
@@ -271,7 +271,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
         	create(cn);
         	
         	cn.commit();
-        } catch (SQLException e) {
+        } catch (SQLException | ValidationException e) {
 			try {
 				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
 				cn.rollback();
@@ -280,6 +280,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 				e1.printStackTrace();
 			}
 			e.printStackTrace();
+			throw new ValidationException(e.getMessage());
 		} finally {
 			try {
 				cn.setAutoCommit(true);

--- a/src/com/cggcoding/models/TreatmentPlan.java
+++ b/src/com/cggcoding/models/TreatmentPlan.java
@@ -31,6 +31,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 	private boolean inProgress;
 	private boolean isTemplate;
 	private boolean completed;
+	private int templateID;
 	
 	private static DatabaseActionHandler dao= new MySQLActionHandler();
 	
@@ -45,24 +46,11 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 		this.inProgress = false;
 		this.isTemplate = false;
 		this.completed = false;
+		this.templateID = 0;
 	}	
-	
-	private TreatmentPlan(int treatmentPlanID, int userID, String title, String description, int txIssueID){
-		this.treatmentPlanID = treatmentPlanID;
-		this.title = title;
-		this.description = description;
-		this.treatmentIssueID = txIssueID;
-		this.userID = userID;
-		this.stages = new ArrayList<>();
-		this.currentStageIndex = 0;
-		this.activeViewStageIndex = 0;
-		this.inProgress = false;
-		this.isTemplate = false;
-		this.completed = false;
-	}
 
 	private TreatmentPlan(int treatmentPlanID, int userID, String title, String description, int txIssueID, boolean inProgress, 
-			boolean isTemplate, boolean completed, int currentStageIndex, int activeViewStageIndex){
+			boolean isTemplate, boolean completed, int currentStageIndex, int activeViewStageIndex, int templateID){
 		this.treatmentPlanID = treatmentPlanID;
 		this.title = title;
 		this.description = description;
@@ -74,6 +62,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 		this.inProgress = inProgress;
 		this.isTemplate = isTemplate;
 		this.completed = completed;
+		this.templateID = templateID;
 	}
 	
 	public static TreatmentPlan getInstanceWithoutID(String title, int userID, String description, int treatmentPlanID){
@@ -81,8 +70,8 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 	}
 	
 	public static TreatmentPlan getInstanceBasic(int treatmentPlanID, int userID, String title, String description, int txIssueID, boolean inProgress, 
-			boolean isTemplate, boolean completed, int currentStageIndex, int activeViewStageIndex){
-		return new TreatmentPlan(treatmentPlanID, userID, title, description, txIssueID, inProgress, isTemplate, completed, currentStageIndex, activeViewStageIndex);
+			boolean isTemplate, boolean completed, int currentStageIndex, int activeViewStageIndex, int templateID){
+		return new TreatmentPlan(treatmentPlanID, userID, title, description, txIssueID, inProgress, isTemplate, completed, currentStageIndex, activeViewStageIndex, templateID);
 	}
 
 	/**Run first time a client loads a plan.  Sets inProgress=true for the TreatmentPlan itself and for the first stage of the plan
@@ -207,6 +196,14 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 
 	public void setCompleted(boolean completed) {
 		this.completed = completed;
+	}
+
+	public int getTemplateID() {
+		return templateID;
+	}
+
+	public void setTemplateID(int templateID) {
+		this.templateID = templateID;
 	}
 
 	public int getNumberOfStages(){

--- a/src/com/cggcoding/models/TreatmentPlan.java
+++ b/src/com/cggcoding/models/TreatmentPlan.java
@@ -269,6 +269,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
         	
         	cn.commit();
         } catch (SQLException | ValidationException e) {
+        	e.printStackTrace();
 			try {
 				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
 				cn.rollback();
@@ -276,8 +277,12 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 				System.out.println(ErrorMessages.ROLLBACK_DB_ERROR);
 				e1.printStackTrace();
 			}
-			e.printStackTrace();
-			throw new ValidationException(e.getMessage());
+			if(e.getClass().getSimpleName().equals("ValidationException")){
+				throw new ValidationException(e.getMessage());
+			}else if(e.getClass().getSimpleName().equals("DatabaseException")){
+				throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			}
+			
 		} finally {
 			try {
 				cn.setAutoCommit(true);
@@ -343,7 +348,8 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
         	updateBasic(cn);
         	
         	cn.commit();
-        } catch (SQLException e) {
+        } catch (SQLException | ValidationException e) {
+        	e.printStackTrace();
 			try {
 				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
 				cn.rollback();
@@ -351,7 +357,11 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 				System.out.println(ErrorMessages.ROLLBACK_DB_ERROR);
 				e1.printStackTrace();
 			}
-			e.printStackTrace();
+			if(e.getClass().getSimpleName().equals("ValidationException")){
+				throw new ValidationException(e.getMessage());
+			}else if(e.getClass().getSimpleName().equals("DatabaseException")){
+				throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			}
 		} finally {
 			try {
 				cn.setAutoCommit(true);
@@ -533,7 +543,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 			
 
 			cn.commit();
-		} catch (SQLException e) {
+		} catch (SQLException | ValidationException e) {
             e.printStackTrace();
             try {
 				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
@@ -542,7 +552,11 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 				e1.printStackTrace();
 				throw new DatabaseException(ErrorMessages.ROLLBACK_DB_ERROR);
 			}
-            throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+            if(e.getClass().getSimpleName().equals("ValidationException")){
+				throw new ValidationException(e.getMessage());
+			}else if(e.getClass().getSimpleName().equals("DatabaseException")){
+				throw new DatabaseException(ErrorMessages.GENERAL_DB_ERROR);
+			}
         } finally {
         	try {
 				cn.setAutoCommit(true);

--- a/src/com/cggcoding/models/TreatmentPlan.java
+++ b/src/com/cggcoding/models/TreatmentPlan.java
@@ -442,11 +442,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 		for(int stageID : stageIDs){
 			plan.addStage(Stage.load(cn, stageID));
 		}
-        
-		if(plan.getStages().size()==0){
-			throw new ValidationException(ErrorMessages.STAGES_IS_EMPTY);
-		}
-		
+
 		return plan;
 	}
 	

--- a/src/com/cggcoding/models/TreatmentPlan.java
+++ b/src/com/cggcoding/models/TreatmentPlan.java
@@ -294,7 +294,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 		
 	}
 	
-	public TreatmentPlan create(Connection cn) throws ValidationException, SQLException{
+	protected TreatmentPlan create(Connection cn) throws ValidationException, SQLException{
 		
 		if(dao.treatmentPlanValidateNewTitle(cn, this.userID, this.title)){
     		dao.treatmentPlanCreateBasic(cn, this);//createBasic(cn);
@@ -327,7 +327,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
         return plan;
 	}
 	
-	public TreatmentPlan createBasic(Connection cn) throws ValidationException, SQLException {
+	protected TreatmentPlan createBasic(Connection cn) throws ValidationException, SQLException {
 		TreatmentPlan plan = null;
 		if(dao.treatmentPlanValidateNewTitle(cn, this.userID, this.title)){
 			dao.treatmentPlanCreateBasic(cn, this);
@@ -380,7 +380,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 		
 	}
 	
-	public void updateBasic(Connection cn) throws ValidationException, SQLException {
+	protected void updateBasic(Connection cn) throws ValidationException, SQLException {
 		if(dao.treatmentPlanValidateUpdatedTitle(cn, this)){
     		dao.treatmentPlanUpdateBasic(cn, this);
     	}
@@ -404,7 +404,7 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 		
 	}
 	
-	public void delete(Connection cn) throws ValidationException, SQLException {
+	protected void delete(Connection cn) throws ValidationException, SQLException {
 		dao.throwValidationExceptionIfTemplateHolderID(this.treatmentPlanID);
 		
 		dao.treatmentPlanDelete(cn, this.treatmentPlanID);

--- a/src/com/cggcoding/models/TreatmentPlan.java
+++ b/src/com/cggcoding/models/TreatmentPlan.java
@@ -310,6 +310,30 @@ public class TreatmentPlan implements Serializable, DatabaseModel{
 		 return this;
 	}
 	
+	public TreatmentPlan createBasic() throws ValidationException, DatabaseException {
+		
+		Connection cn = null;
+        TreatmentPlan plan = null;
+        try {
+        	cn = dao.getConnection();  	
+        	plan = createBasic(cn);
+        } catch (SQLException e) {
+			e.printStackTrace();
+		} finally {
+			DbUtils.closeQuietly(cn);
+        }
+        
+        return plan;
+	}
+	
+	public TreatmentPlan createBasic(Connection cn) throws ValidationException, SQLException {
+		TreatmentPlan plan = null;
+		if(dao.treatmentPlanValidateNewTitle(cn, this.userID, this.title)){
+			dao.treatmentPlanCreateBasic(cn, this);
+		}
+		return plan;
+	}
+	
 	@Override
 	public void update() throws ValidationException, DatabaseException {
 		Connection cn = null;

--- a/src/com/cggcoding/models/User.java
+++ b/src/com/cggcoding/models/User.java
@@ -200,6 +200,8 @@ public abstract class User implements Serializable{
     	//OPTIMIZE O(N3) complexity here with 3 nested for loops.  Is there a better way to do this?
     	for(Stage stage : planToCopy.getStages()){
     		stage.setUserID(userIDTakingNewPlan);
+    		stage.setTemplate(false);
+    		//stage.setTemplateID(stage.getStageID());TODO uncomment this once added templateID to Stage
     		List<Task> taskRepetitionsAdded = new ArrayList<>();
     		for(Task task : stage.getTasks()){
     			task.setUserID(userIDTakingNewPlan);

--- a/src/com/cggcoding/models/User.java
+++ b/src/com/cggcoding/models/User.java
@@ -132,64 +132,6 @@ public abstract class User implements Serializable{
 		return true;
 	}
 	
-	//XXX change this to nest copy() - stage.copy(userID)?
-	/*public TreatmentPlan copyTreatmentPlanForClient(int userIDTakingNewPlan, int treatmentPlanIDBeingCopied, boolean isTemplate) throws ValidationException, DatabaseException{
-    	TreatmentPlan planToCopy = TreatmentPlan.load(treatmentPlanIDBeingCopied);
-    	List<Stage> stages = planToCopy.getStages();
-    	
-    	if(planToCopy.getStages().size()==0){
-			throw new ValidationException(ErrorMessages.STAGES_IS_EMPTY);
-		}
-    	
-    	planToCopy.setTemplate(isTemplate);
-    	
-    	planToCopy.setUserID(userIDTakingNewPlan);
-
-    	Connection cn = null;
-        
-        try {
-        	cn = dao.getConnection();
-        	cn.setAutoCommit(false);
-        	
-        	planToCopy = planToCopy.createBasic(cn);//XXX Check that this updates the treatmentPlanID correctly
-        	
-        	//loop through and copy into the new plan
-        	for(Stage stage : stages){
-        		//OPTIMIZE the following lines of code are repeated in TreatmentPlan.copyStageIntoTreatmentPlan.  I couldn't figure out a way to use that method since I need to know the state of a TreatmentPlan's isTemplate to determine if repetitions are made, so can't do that from Stage.java
-        		stage.setUserID(userIDTakingNewPlan);
-        		stage.setTemplate(false);
-        		stage.setTreatmentPlanID(planToCopy.getTreatmentPlanID());//set with new treatmentPlanID that was created when .createBasic was called earlier
-        		for(Task task : stage.getTasks()){
-        			task.setUserID(userIDTakingNewPlan);
-        			task.setTemplate(false);
-        			task.setStageID(stageID);
-        		}
-        	}
-        	
-        	cn.commit();
-        } catch (SQLException e) {
-			try {
-				System.out.println(ErrorMessages.ROLLBACK_DB_OP);
-				cn.rollback();
-			} catch (SQLException e1) {
-				System.out.println(ErrorMessages.ROLLBACK_DB_ERROR);
-				e1.printStackTrace();
-			}
-			e.printStackTrace();
-		} finally {
-			try {
-				cn.setAutoCommit(true);
-			} catch (SQLException e) {
-				e.printStackTrace();
-			}
-			DbUtils.closeQuietly(cn);
-        }
-    	
-    	//save the plan - which is responsible for updating treatmentPlanID in all the child objects
-    	return planToCopy.create();
-    	
-    }*/
-	
 	
 	 public TreatmentPlan copyTreatmentPlanForClient(int userIDTakingNewPlan, int treatmentPlanIDBeingCopied, boolean isTemplate) throws ValidationException, DatabaseException{
     	TreatmentPlan planToCopy = TreatmentPlan.load(treatmentPlanIDBeingCopied);

--- a/src/com/cggcoding/models/User.java
+++ b/src/com/cggcoding/models/User.java
@@ -10,6 +10,7 @@ import com.cggcoding.exceptions.DatabaseException;
 import com.cggcoding.exceptions.ValidationException;
 import com.cggcoding.utils.database.DatabaseActionHandler;
 import com.cggcoding.utils.database.MySQLActionHandler;
+import com.cggcoding.utils.messaging.ErrorMessages;
 
 public abstract class User implements Serializable{
 	/**
@@ -128,8 +129,14 @@ public abstract class User implements Serializable{
 		return true;
 	}
 	
+	//XXX change this to nest copy() - stage.copy(userID)?
 	public TreatmentPlan copyTreatmentPlanForClient(int userIDTakingNewPlan, int treatmentPlanIDBeingCopied, boolean isTemplate) throws ValidationException, DatabaseException{
     	TreatmentPlan planToCopy = TreatmentPlan.load(treatmentPlanIDBeingCopied);
+    	
+    	if(planToCopy.getStages().size()==0){
+			throw new ValidationException(ErrorMessages.STAGES_IS_EMPTY);
+		}
+    	
     	planToCopy.setTemplate(isTemplate);
     	
     	planToCopy.setUserID(userIDTakingNewPlan);

--- a/src/com/cggcoding/models/User.java
+++ b/src/com/cggcoding/models/User.java
@@ -194,7 +194,7 @@ public abstract class User implements Serializable{
 	 public TreatmentPlan copyTreatmentPlanForClient(int userIDTakingNewPlan, int treatmentPlanIDBeingCopied, boolean isTemplate) throws ValidationException, DatabaseException{
     	TreatmentPlan planToCopy = TreatmentPlan.load(treatmentPlanIDBeingCopied);
     	planToCopy.setTemplate(isTemplate);
-    	
+    	planToCopy.setTemplateID(planToCopy.getTreatmentPlanID());
     	planToCopy.setUserID(userIDTakingNewPlan);
     	//loop through and change all the userIDs to the userID supplied by the method argument
     	//OPTIMIZE O(N3) complexity here with 3 nested for loops.  Is there a better way to do this?

--- a/src/com/cggcoding/models/User.java
+++ b/src/com/cggcoding/models/User.java
@@ -197,16 +197,27 @@ public abstract class User implements Serializable{
     	
     	planToCopy.setUserID(userIDTakingNewPlan);
     	//loop through and change all the userIDs to the userID supplied by the method argument
+    	//OPTIMIZE O(N3) complexity here with 3 nested for loops.  Is there a better way to do this?
     	for(Stage stage : planToCopy.getStages()){
     		stage.setUserID(userIDTakingNewPlan);
+    		List<Task> taskRepetitionsAdded = new ArrayList<>();
     		for(Task task : stage.getTasks()){
-    			if(task.getRepetitions() > 1){
-    				//TODO add repetitions here
-    			}
     			task.setUserID(userIDTakingNewPlan);
-    		}
-    		//TODO before moving on to next stage in loop, update the task orders to account for any repetitions added
-    	}
+    			task.setTemplate(false);
+    			task.setTemplateID(task.getTaskID());
+    			for(int i = 0; i < task.getRepetitions(); i++){
+    				Task taskRep = task.copy();
+    				taskRep.setTaskOrder(taskRepetitionsAdded.size()-1);
+    				taskRepetitionsAdded.add(taskRep);
+    			}
+    			
+    		}//end Task loop
+    		
+    		//reset the Stage's Task list with new list that has been populated with repetitions
+    		stage.setTasks(taskRepetitionsAdded);
+    		
+    		//TODO before moving on to next stage in loop, update the task orders to account for any repetitions added?
+    	}//end Stage loop
     	
     	//save the plan - which is responsible for updating treatmentPlanID in all the child objects
     	return planToCopy.create();

--- a/src/com/cggcoding/models/User.java
+++ b/src/com/cggcoding/models/User.java
@@ -207,7 +207,12 @@ public abstract class User implements Serializable{
     			task.setTemplateID(task.getTaskID());
     			for(int i = 0; i < task.getRepetitions(); i++){
     				Task taskRep = task.copy();
-    				taskRep.setTaskOrder(taskRepetitionsAdded.size()-1);
+    				
+    				if(task.getRepetitions() > 1){
+    					taskRep.setTitle(task.getTitle() + " (" + (i+1) + ")");
+    				}
+    				
+    				taskRep.setTaskOrder(taskRepetitionsAdded.size());
     				taskRepetitionsAdded.add(taskRep);
     			}
     			

--- a/src/com/cggcoding/models/User.java
+++ b/src/com/cggcoding/models/User.java
@@ -201,7 +201,7 @@ public abstract class User implements Serializable{
     	for(Stage stage : planToCopy.getStages()){
     		stage.setUserID(userIDTakingNewPlan);
     		stage.setTemplate(false);
-    		//stage.setTemplateID(stage.getStageID());TODO uncomment this once added templateID to Stage
+    		stage.setTemplateID(stage.getStageID());
     		List<Task> taskRepetitionsAdded = new ArrayList<>();
     		for(Task task : stage.getTasks()){
     			task.setUserID(userIDTakingNewPlan);

--- a/src/com/cggcoding/utils/database/DatabaseActionHandler.java
+++ b/src/com/cggcoding/utils/database/DatabaseActionHandler.java
@@ -163,6 +163,13 @@ public interface DatabaseActionHandler {
 
 	boolean throwValidationExceptionIfNull(Object o) throws ValidationException;
 
+	List<Task> stageLoadTaskTemplates(Connection cn, int stageID) throws SQLException;
+
+	void mapsTaskStageTemplateCreate(Connection cn, int taskTemplateID, int stageTemplateID) throws SQLException;
+
+	boolean mapsTaskStageTemplateValidate(Connection cn, int taskTemplateID, int stageTemplateID)
+			throws ValidationException, SQLException;
+
 
 	
 

--- a/src/com/cggcoding/utils/database/DatabaseActionHandler.java
+++ b/src/com/cggcoding/utils/database/DatabaseActionHandler.java
@@ -44,7 +44,7 @@ public interface DatabaseActionHandler {
 
 	TreatmentPlan treatmentPlanLoadBasic(Connection cn, int treatmentPlanID) throws SQLException, ValidationException;
 
-	List<Integer> treatmentPlanGetStageIDs(Connection cn, int treatmentPlanID) throws SQLException, ValidationException;
+	List<Stage> treatmentPlanLoadStages(Connection cn, int treatmentPlanID) throws SQLException, ValidationException;
 
 	boolean treatmentPlanValidateNewTitle(Connection cn, int userID, String planTitle)
 			throws ValidationException, SQLException;
@@ -67,6 +67,8 @@ public interface DatabaseActionHandler {
 	List<TreatmentPlan> treatmentPlanGetDefaults() throws DatabaseException, ValidationException;
 	
 	void treatmentPlanDelete(Connection cn, int treatmentPlanID) throws SQLException, ValidationException;
+	
+	List<Stage> treatmentPlanLoadStageTemplates(Connection cn, int treatmentPlanID) throws SQLException, ValidationException;
 	
 
 	//**************************************************************************************************
@@ -96,6 +98,7 @@ public interface DatabaseActionHandler {
 	 */
 	List<Stage> stagesGetDefaults() throws DatabaseException, ValidationException;
 	
+	List<Task> stageLoadTaskTemplates(Connection cn, int stageID) throws SQLException;
 	
 	//**************************************************************************************************
 	//*************************************** Stage Goal Methods ***************************************
@@ -163,12 +166,18 @@ public interface DatabaseActionHandler {
 
 	boolean throwValidationExceptionIfNull(Object o) throws ValidationException;
 
-	List<Task> stageLoadTaskTemplates(Connection cn, int stageID) throws SQLException;
-
 	void mapsTaskStageTemplateCreate(Connection cn, int taskTemplateID, int stageTemplateID) throws SQLException;
 
 	boolean mapsTaskStageTemplateValidate(Connection cn, int taskTemplateID, int stageTemplateID)
 			throws ValidationException, SQLException;
+
+	void mapsStageTreatmentPlanTemplateCreate(Connection cn, int stageTemplateID, int treatmentPlanTemplateID)
+			throws SQLException;
+
+	boolean mapsStageTreatmentPlanTemplateValidate(Connection cn, int stageTemplateID, int treatmentPlanTemplateID)
+			throws ValidationException, SQLException;
+
+	
 
 
 	

--- a/src/com/cggcoding/utils/database/DatabaseActionHandler.java
+++ b/src/com/cggcoding/utils/database/DatabaseActionHandler.java
@@ -70,7 +70,9 @@ public interface DatabaseActionHandler {
 	
 	List<Stage> treatmentPlanLoadStageTemplates(Connection cn, int treatmentPlanID) throws SQLException, ValidationException;
 	
-
+	List<Stage> treatmentPlanUpdateStageTemplates(Connection cn, int treatmentPlanID, List<Stage> stageTemplates)
+			throws SQLException;
+	
 	//**************************************************************************************************
 	//****************************************** Stage Methods *****************************************
 	//**************************************************************************************************
@@ -182,6 +184,8 @@ public interface DatabaseActionHandler {
 	void mapsTaskStageTemplateDelete(Connection cn, int taskID) throws SQLException;
 
 	void mapsStageTreatmentPlanTemplateDelete(Connection cn, int stageID) throws SQLException;
+
+	
 
 	
 

--- a/src/com/cggcoding/utils/database/DatabaseActionHandler.java
+++ b/src/com/cggcoding/utils/database/DatabaseActionHandler.java
@@ -100,6 +100,8 @@ public interface DatabaseActionHandler {
 	
 	List<Task> stageLoadTaskTemplates(Connection cn, int stageID) throws SQLException;
 	
+	List<Task> stageUpdateTaskTemplates(Connection cn, int stageID, List<Task> taskTemplates) throws SQLException;
+	
 	//**************************************************************************************************
 	//*************************************** Stage Goal Methods ***************************************
 	//**************************************************************************************************
@@ -166,16 +168,22 @@ public interface DatabaseActionHandler {
 
 	boolean throwValidationExceptionIfNull(Object o) throws ValidationException;
 
-	void mapsTaskStageTemplateCreate(Connection cn, int taskTemplateID, int stageTemplateID) throws SQLException;
+	void mapsTaskStageTemplateCreate(Connection cn, int taskTemplateID, int stageTemplateID, int taskOrder) throws SQLException;
 
 	boolean mapsTaskStageTemplateValidate(Connection cn, int taskTemplateID, int stageTemplateID)
 			throws ValidationException, SQLException;
 
-	void mapsStageTreatmentPlanTemplateCreate(Connection cn, int stageTemplateID, int treatmentPlanTemplateID)
+	void mapsStageTreatmentPlanTemplateCreate(Connection cn, int stageTemplateID, int treatmentPlanTemplateID, int stageOrder)
 			throws SQLException;
 
 	boolean mapsStageTreatmentPlanTemplateValidate(Connection cn, int stageTemplateID, int treatmentPlanTemplateID)
 			throws ValidationException, SQLException;
+
+	void mapsTaskStageTemplateDelete(Connection cn, int taskID) throws SQLException;
+
+	void mapsStageTreatmentPlanTemplateDelete(Connection cn, int stageID) throws SQLException;
+
+	
 
 	
 

--- a/src/com/cggcoding/utils/database/MySQLActionHandler.java
+++ b/src/com/cggcoding/utils/database/MySQLActionHandler.java
@@ -972,7 +972,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
             	task = TaskGeneric.getInstanceFull(rs.getInt("task_generic_id"), rs.getInt("task_generic_stage_id_fk"), rs.getInt("task_generic_user_id_fk"), rs.getInt("task_generic_task_type_id_fk"), 
             			rs.getInt("parent_task_id"), rs.getString("task_title"), rs.getString("instructions"), rs.getString("resource_link"), rs.getBoolean("task_completed"), 
             			dateCompleted, rs.getInt("task_order"), rs.getBoolean("is_extra_task"), 
-            			rs.getBoolean("task_is_template"), rs.getInt("template_id"), rs.getInt("repetitions"));
+            			rs.getBoolean("task_is_template"), rs.getInt("task_template_id"), rs.getInt("repetitions"));
             }
 
         } finally {
@@ -1078,7 +1078,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
         try {
 
 	    		String sql = "UPDATE task_generic SET task_generic_task_type_id_fk=?, task_generic_stage_id_fk=?, task_generic_user_id_fk=?, parent_task_id=?, task_title=?, instructions=?, resource_link=?, "
-	    				+ "task_completed=?, task_date_completed=?, task_order=?, is_extra_task=?, task_is_template=?, template_id=?, repetitions=? WHERE task_generic_id=?";
+	    				+ "task_completed=?, task_date_completed=?, task_order=?, is_extra_task=?, task_is_template=?, task_template_id=?, repetitions=? WHERE task_generic_id=?";
 	        	
 	            ps = cn.prepareStatement(sql);
 	            
@@ -1153,7 +1153,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
         
         try {
         	String sql = "INSERT INTO task_generic (task_generic_task_type_id_fk, task_generic_stage_id_fk, task_generic_user_id_fk, parent_task_id, task_title, "
-        			+ "instructions, resource_link, task_completed, task_date_completed, task_order, is_extra_task, task_is_template, template_id, repetitions) "
+        			+ "instructions, resource_link, task_completed, task_date_completed, task_order, is_extra_task, task_is_template, task_template_id, repetitions) "
     				+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         	
             ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);

--- a/src/com/cggcoding/utils/database/MySQLActionHandler.java
+++ b/src/com/cggcoding/utils/database/MySQLActionHandler.java
@@ -799,17 +799,15 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
         ResultSet rs = null;
         List<Task> tasks = new ArrayList<>();
         
-        //throwValidationExceptionIfTemplateHolderID(stageID);
-        
         try {
-            ps = cn.prepareStatement("SELECT task_generic_id FROM task_template_id_stage_template_id_maps WHERE stage_template_id_fk=?");
+            ps = cn.prepareStatement("SELECT task_generic_template_id_fk FROM task_template_id_stage_template_id_maps WHERE stage_template_id_fk=?");
             ps.setInt(1, stageID);
             
 
             rs = ps.executeQuery();
             
             while (rs.next()){
-            	tasks.add(Task.load(cn, rs.getInt("task_generic_id")));
+            	tasks.add(Task.load(cn, rs.getInt("task_generic_template_id_fk")));
             }
             //TODO confirm that the order of tasks is correct when loaded here
         } finally {

--- a/src/com/cggcoding/utils/database/MySQLActionHandler.java
+++ b/src/com/cggcoding/utils/database/MySQLActionHandler.java
@@ -335,7 +335,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
             	plan = TreatmentPlan.getInstanceBasic(rsPlanInfo.getInt("treatment_plan_id"), rsPlanInfo.getInt("treatment_plan_user_id_fk"), 
             			rsPlanInfo.getString("treatment_plan_title"), rsPlanInfo.getString("treatment_plan_description"), rsPlanInfo.getInt("treatment_plan_treatment_issue_id_fk"),
             			rsPlanInfo.getBoolean("in_progress"), rsPlanInfo.getBoolean("treatment_plan_is_template"), rsPlanInfo.getBoolean("treatment_plan_completed"),
-            			rsPlanInfo.getInt("current_stage_index"), rsPlanInfo.getInt("active_view_stage_index"));
+            			rsPlanInfo.getInt("current_stage_index"), rsPlanInfo.getInt("active_view_stage_index"), rsPlanInfo.getInt("template_id"));
             	
             }
             
@@ -439,8 +439,8 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
         
         try {
         	String sql = "INSERT INTO treatment_plan (treatment_plan_user_id_fk, treatment_plan_treatment_issue_id_fk, treatment_plan_title, treatment_plan_description, "
-        			+ "current_stage_index, active_view_stage_index, in_progress, treatment_plan_is_template) "
-            		+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        			+ "current_stage_index, active_view_stage_index, in_progress, treatment_plan_is_template, template_id) "
+            		+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
         	
             ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             
@@ -452,6 +452,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
             ps.setInt(6, treatmentPlan.getActiveViewStageIndex());
             ps.setBoolean(7, treatmentPlan.isInProgress());
             ps.setBoolean(8, treatmentPlan.isTemplate());
+            ps.setInt(9, treatmentPlan.getTemplateID());
 
             int success = ps.executeUpdate();
             
@@ -511,7 +512,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
         
         try {
         	String sql = "UPDATE treatment_plan SET treatment_plan_user_id_fk=?, treatment_plan_treatment_issue_id_fk=?, treatment_plan_title=?, treatment_plan_description=?, current_stage_index=?, "
-        			+ "active_view_stage_index=?, in_progress=?, treatment_plan_is_template=?, treatment_plan_completed=? WHERE treatment_plan_id=?";
+        			+ "active_view_stage_index=?, in_progress=?, treatment_plan_is_template=?, treatment_plan_completed=?, template_id=? WHERE treatment_plan_id=?";
         	
             ps = cn.prepareStatement(sql);
             
@@ -524,7 +525,8 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
             ps.setBoolean(7, treatmentPlan.isInProgress());
             ps.setBoolean(8, treatmentPlan.isTemplate());
             ps.setBoolean(9, treatmentPlan.isCompleted());
-            ps.setInt(10, treatmentPlan.getTreatmentPlanID());
+            ps.setInt(10, treatmentPlan.getTemplateID());
+            ps.setInt(11, treatmentPlan.getTreatmentPlanID());
 
             int success = ps.executeUpdate();
 

--- a/src/com/cggcoding/utils/database/MySQLActionHandler.java
+++ b/src/com/cggcoding/utils/database/MySQLActionHandler.java
@@ -671,8 +671,8 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
         ResultSet generatedKeys = null;
         
         try {
-    		String sql = "INSERT INTO stage (stage_user_id_fk, stage_treatment_plan_id_fk, stage_title, stage_description, stage_completed, stage_order, percent_complete, stage_in_progress, stage_is_template) "
-            		+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    		String sql = "INSERT INTO stage (stage_user_id_fk, stage_treatment_plan_id_fk, stage_title, stage_description, stage_completed, stage_order, percent_complete, stage_in_progress, stage_is_template, template_id) "
+            		+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         	
             ps = cn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
             
@@ -685,6 +685,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
             ps.setDouble(7, newStage.getPercentComplete());
             ps.setBoolean(8, newStage.isInProgress());
             ps.setBoolean(9, newStage.isTemplate());
+            ps.setInt(10, newStage.getTemplateID());
 
             int success = ps.executeUpdate();
             
@@ -717,7 +718,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
         
         try {
         		
-    		String sql = "UPDATE stage SET stage_treatment_plan_id_fk=?, stage_user_id_fk=?, stage_title=?, stage_description=?, stage_completed=?, `stage_order`=?, percent_complete=?, stage_in_progress=?, stage_is_template=? WHERE stage_id=?";
+    		String sql = "UPDATE stage SET stage_treatment_plan_id_fk=?, stage_user_id_fk=?, stage_title=?, stage_description=?, stage_completed=?, `stage_order`=?, percent_complete=?, stage_in_progress=?, stage_is_template=?, template_id=? WHERE stage_id=?";
         	
             ps = cn.prepareStatement(sql);
 
@@ -730,7 +731,8 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
             ps.setDouble(7, stage.getPercentComplete());
             ps.setBoolean(8, stage.isInProgress());
             ps.setBoolean(9, stage.isTemplate());
-            ps.setInt(10, stage.getStageID());
+            ps.setInt(10, stage.getTemplateID());
+            ps.setInt(11, stage.getStageID());
 
             success = ps.executeUpdate();
         	
@@ -812,7 +814,7 @@ public class MySQLActionHandler implements Serializable, DatabaseActionHandler{
             	//boolean inProgress = rs.getInt("") == 1;
             	//boolean isTemplate = rs.getInt("stage_is_template") == 1;
             	
-            	stage = Stage.getInstance(stageID, rs.getInt("stage_treatment_plan_id_fk"), rs.getInt("stage.stage_user_id_fk"), rs.getString("stage.stage_title"), rs.getString("stage.stage_description"), rs.getInt("stage.stage_order"), tasks, extraTasks, rs.getBoolean("stage_completed"), rs.getDouble("percent_complete"), goals, rs.getBoolean("stage_in_progress"), rs.getBoolean("stage_is_template"));
+            	stage = Stage.getInstance(stageID, rs.getInt("stage_treatment_plan_id_fk"), rs.getInt("stage.stage_user_id_fk"), rs.getString("stage.stage_title"), rs.getString("stage.stage_description"), rs.getInt("stage.stage_order"), tasks, extraTasks, rs.getBoolean("stage_completed"), rs.getDouble("percent_complete"), goals, rs.getBoolean("stage_in_progress"), rs.getBoolean("stage_is_template"), rs.getInt("template_id"));
             }
 
         } finally {

--- a/src/com/cggcoding/utils/messaging/ErrorMessages.java
+++ b/src/com/cggcoding/utils/messaging/ErrorMessages.java
@@ -26,7 +26,7 @@ public final class ErrorMessages {
 	public static final String ISSUE_NAME_MISSING = "You entered a blank treatment issue.  Please try again.";
 	public static final String STAGE_TITLE_EXISTS = "The stage name you entered already exists in your profile. Please use another name. If you'd like to view or edit the existing task, <a href=#>click here</a>";
 	public static final String PLAN_DELETE_ERROR = "There is no treatment plan selected to delete.";
-	public static final String STAGES_IS_EMPTY = "There are no stages in this treatment plan.";
+	public static final String STAGES_IS_EMPTY = "There are no stages in this treatment plan. A plan must have at least one stage to be assigned to a client.";
 	
 	//Stages
 	public static final String STAGE_GOAL_VALIDATION_ERROR = "You must enter a goal description.";

--- a/src/com/cggcoding/utils/messaging/ErrorMessages.java
+++ b/src/com/cggcoding/utils/messaging/ErrorMessages.java
@@ -5,15 +5,15 @@ public final class ErrorMessages {
 	//Database errors
 	public static final String CONNECTION_IS_NULL = "Unable to establish a connection to the database.";	
 	public static final String GENERAL_DB_ERROR = "There seems to be a problem performing the database operation you requested.  Please try again or contact customer support.";
-		public static final String ROLLBACK_DB_OP = "An error has occured while performing the database opertion you request and the data has been rolled back to its previous state.";
-		public static final String ROLLBACK_DB_ERROR = "An error has occured while performing the database opertion you request and also a problem reverting your data back to it's original state.  Please contact customer support.";
+	public static final String ROLLBACK_DB_OP = "An error has occured while performing the database opertion you request and the data has been rolled back to its previous state.";
+	public static final String ROLLBACK_DB_ERROR = "An error has occured while performing the database opertion you request and also a problem reverting your data back to it's original state.  Please contact customer support.";
 		
 	//General Validation errors
-		public static final String GENERAL_VALIDATION_ERROR = "There was an error validating your request.  Please try againg or contact customer support.";
-		public static final String VALIDATION_ERROR_UPDATING_DATA = "The data you are trying to update contains invalid information.  Please try again.";
-		public static final String DEFAULTS_HOLDER_ID_SELECTED = "It appears you are trying to access restricted data.  Please be sure to make a valid selection and try again.";
-		public static final String OBJECT_IS_NULL = "It appears there is no database record for what you are looking for.  Please be sure to make a valid selection and try again.  If you have further problems please contact customer support.";
-		
+	public static final String GENERAL_VALIDATION_ERROR = "There was an error validating your request.  Please try againg or contact customer support.";
+	public static final String VALIDATION_ERROR_UPDATING_DATA = "The data you are trying to update contains invalid information.  Please try again.";
+	public static final String DEFAULTS_HOLDER_ID_SELECTED = "It appears you are trying to access restricted data.  Please be sure to make a valid selection and try again.";
+	public static final String OBJECT_IS_NULL = "It appears there is no database record for what you are looking for.  Please be sure to make a valid selection and try again.  If you have further problems please contact customer support.";
+	
 	//Log in
 	public static final String INVALID_USERNAME_OR_PASSWORD = "Login failed.  The email and password combination is not found in our records.  Please try again.";
 

--- a/src/com/cggcoding/utils/messaging/ErrorMessages.java
+++ b/src/com/cggcoding/utils/messaging/ErrorMessages.java
@@ -32,6 +32,8 @@ public final class ErrorMessages {
 	public static final String STAGE_GOAL_VALIDATION_ERROR = "You must enter a goal description.";
 	public static final String STAGE_UPDATE_NO_SELECTION = "Please select and load a stage.";
 	public static final String STAGE_TITLE_DESCRIPTION_MISSING = "You must enter a stage name and description.";
+	public static final String STAGE_IS_NOT_TEMPLATE = "You appear to be trying to add a task template to a stage that is not a template.  This is not allowed.  Please try again or contact customer support.";
+	public static final String STAGE_CONTAINS_TASK_TEMPLATE = "This stage template already contains the task you've chosen.  Go to the Edit Task page to increase the number of repetitions for this task.";
 	
 	//Tasks
 	public static final String TASK_MISSING_INFO = "You must select a task type as well as enter a task name and instructions.";

--- a/src/com/cggcoding/utils/messaging/ErrorMessages.java
+++ b/src/com/cggcoding/utils/messaging/ErrorMessages.java
@@ -27,7 +27,9 @@ public final class ErrorMessages {
 	public static final String STAGE_TITLE_EXISTS = "The stage name you entered already exists in your profile. Please use another name. If you'd like to view or edit the existing task, <a href=#>click here</a>";
 	public static final String PLAN_DELETE_ERROR = "There is no treatment plan selected to delete.";
 	public static final String STAGES_IS_EMPTY = "There are no stages in this treatment plan. A plan must have at least one stage to be assigned to a client.";
-	
+	public static final String PLAN_IS_NOT_TEMPLATE = "You appear to be trying to add a stage template to a treatment plan that is not a template.  This is not allowed.  Please try again or contact customer support.";
+	public static final String PLAN_CONTAINS_STAGE_TEMPLATE = "This treatment plan template already contains the stage you've chosen.  Go to the Edit Stage page if you'd like to edit this stage's template.";
+
 	//Stages
 	public static final String STAGE_GOAL_VALIDATION_ERROR = "You must enter a goal description.";
 	public static final String STAGE_UPDATE_NO_SELECTION = "Please select and load a stage.";

--- a/src/com/cggcoding/utils/messaging/ErrorMessages.java
+++ b/src/com/cggcoding/utils/messaging/ErrorMessages.java
@@ -13,6 +13,7 @@ public final class ErrorMessages {
 	public static final String VALIDATION_ERROR_UPDATING_DATA = "The data you are trying to update contains invalid information.  Please try again.";
 	public static final String DEFAULTS_HOLDER_ID_SELECTED = "It appears you are trying to access restricted data.  Please be sure to make a valid selection and try again.";
 	public static final String OBJECT_IS_NULL = "It appears there is no database record for what you are looking for.  Please be sure to make a valid selection and try again.  If you have further problems please contact customer support.";
+	public static final String NOTHING_SELECTED = "You have not selected anything to update.  Please make a selection and try again.";
 	
 	//Log in
 	public static final String INVALID_USERNAME_OR_PASSWORD = "Login failed.  The email and password combination is not found in our records.  Please try again.";

--- a/src/com/cggcoding/utils/messaging/WarningMessages.java
+++ b/src/com/cggcoding/utils/messaging/WarningMessages.java
@@ -1,0 +1,11 @@
+package com.cggcoding.utils.messaging;
+
+public class WarningMessages {
+
+	public WarningMessages() {
+		
+	}
+	
+	public static final String EDITING_TASK_TEMPLATE = "You are editing a template, so any changes you make to this Task will propogate to all other Stages that use this Task.  Please edit with care.";
+
+}

--- a/src/com/cggcoding/utils/messaging/WarningMessages.java
+++ b/src/com/cggcoding/utils/messaging/WarningMessages.java
@@ -6,6 +6,7 @@ public class WarningMessages {
 		
 	}
 	
-	public static final String EDITING_TASK_TEMPLATE = "You are editing a template, so any changes you make to this Task will propogate to all other Stages that use this Task.  Please edit with care.";
+	public static final String EDITING_TASK_TEMPLATE = "You are editing a template, so any changes you make to this Task will propagate to all other Stages that use this Task.  Please edit with care.";
+	public static final String EDITING_STAGE_TEMPLATE = "You are editing a template, so any changes you make to this Stage will propagate to all other Treatment Plans that use this Stage.  Please edit with care.";
 
 }


### PR DESCRIPTION
finished implementing repetitions.  Also revamped how templates were being used.  Now all children of a template model will also be templates.  Before, children were created by making copies of their master template and it created unnecessary rows in the database and made it much harder to edit plans.
